### PR TITLE
CRM-12593

### DIFF
--- a/modules/views/civicrm/civicrm_handler_relationship_contact2users.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_contact2users.inc
@@ -70,7 +70,7 @@ class civicrm_handler_relationship_contact2users extends views_handler_relations
 
     $alias = $join->definition['table'] . '_' . $join->definition['left_table'];
 
-    $this->alias = $this->query->add_relationship($alias, $join, 'users', $this->relationship);
+    $this->alias = $this->query->add_relationship($alias, $join, 'users');
   }
 }
 


### PR DESCRIPTION
---
- CRM-12593: CiviCRM Views: "CiviCRM Contacts: Drupal ID" fails for chained relationships. Fix attached.
  http://issues.civicrm.org/jira/browse/CRM-12593
