### PR TITLE
CRM-12874

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -364,8 +364,19 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
   $siteRoot   = drush_get_context('DRUSH_DRUPAL_SITE_ROOT', FALSE);
   $crmPath    = "$modPath/civicrm";
 
-  $settingsTplFile = "$crmPath/templates/CRM/common/civicrm.settings.php.template";
-  if (!file_exists($settingsTplFile)) {
+  $files = array(
+    "$crmPath/templates/CRM/common/civicrm.settings.php.template",
+    "$crmPath/templates/CRM/common/civicrm.settings.php.tpl"
+  );
+
+  $settingsTplFile = NULL;
+  foreach ($files as $file) {
+    if (file_exists($file)) {
+      $settingsTplFile = $file;
+    }
+  }
+
+  if (!$settingsTplFile) {
     drush_die(dt("Could not find CiviCRM settings template and therefore could not create settings file."));
   }
 

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -364,7 +364,7 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
   $siteRoot   = drush_get_context('DRUSH_DRUPAL_SITE_ROOT', FALSE);
   $crmPath    = "$modPath/civicrm";
 
-  $settingsTplFile = "$crmPath/templates/CRM/common/civicrm.settings.php.tpl";
+  $settingsTplFile = "$crmPath/templates/CRM/common/civicrm.settings.php.template";
   if (!file_exists($settingsTplFile)) {
     drush_die(dt("Could not find CiviCRM settings template and therefore could not create settings file."));
   }


### PR DESCRIPTION
Renamed it to civicrm.settings.php.template

CRM-12874: Rename civicrm.settings.php.tpl so it isn't in the same suffix as Smarty templates http://issues.civicrm.org/jira/browse/CRM-12874
