### PR TITLE
CRM-12853 Case/Views integration

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -76,6 +76,7 @@ function civicrm_views_data_alter(&$data) {
   require_once 'CRM/Core/Error.php';
   require_once 'CRM/Contact/BAO/Contact.php';
   require_once 'CRM/Event/BAO/Query.php';
+  require_once 'CRM/Case/BAO/Case.php';
   require_once 'components/civicrm.core.inc';
 
   // Get list of enabled CiviCRM components
@@ -113,6 +114,10 @@ function civicrm_views_data_alter(&$data) {
   if (isset($enabled['CiviMember'])) {
     include_once 'components/civicrm.member.inc';
     _civicrm_member_data($data, $enabled);
+  }
+  if (isset($enabled['CiviCase'])) {
+    include_once 'components/civicrm.case.inc';
+    _civicrm_case_data($data, $enabled);
   }
 
   return $data;
@@ -348,6 +353,10 @@ function civicrm_views_custom_data_cache(&$data, $entity_type, $groupID, $subTyp
     case "Campaign":
     case "Survey":
       $jointable = 'civicrm_campaign';
+      break;
+
+    case "Case":
+      $jointable = 'civicrm_case';
       break;
   }
 
@@ -700,6 +709,8 @@ function civicrm_date_views_fields($field) {
     case 'civicrm_activity.activity_date_time':
     case 'civicrm_campaign.start_date':
     case 'civicrm_campaign.end_date':
+    case 'civicrm_case.start_date':
+    case 'civicrm_case.end_date':
       return $values;
   }
 }
@@ -711,6 +722,7 @@ function civicrm_date_views_tables() {
   return array(
     'civicrm_mailing_job',
     'civicrm_event',
+    'civicrm_case',
     'civicrm_activity',
     'civicrm_campaign',
   );
@@ -750,6 +762,18 @@ function civicrm_views_plugins() {
           'uses fields' => TRUE,
           'type' => 'normal',
           'dao class' => 'CRM_Activity_DAO_Activity',
+          'title field' => 'subject',
+        ),
+	'civicrm_case_calendar' => array(
+          'title' => t('Case Items'),
+          'help' => t('Displays each selected case as a Calendar item.'),
+          'handler' => 'calendar_plugin_row_civicrm',
+          'path' => "$civicrm_module_path/modules/views/plugins",
+          'base' => array('civicrm_case'),
+          'uses options' => TRUE,
+          'uses fields' => TRUE,
+          'type' => 'normal',
+          'dao class' => 'CRM_Case_DAO_Case',
           'title field' => 'subject',
         ),
         'civicrm_mail_calendar' => array(

--- a/modules/views/civicrm/civicrm_handler_field_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_field_pseudo_constant.inc
@@ -57,7 +57,9 @@ class civicrm_handler_field_pseudo_constant extends views_handler_field {
 
   function render($values) {
     if (!empty($values->{$this->field_alias})) {
-      return $this->_pseudo_constant[$values->{$this->field_alias}];
+      $val = $values->{$this->field_alias};
+      $val = str_replace("\x01", '', $val); // TODO This fix should be replaced as described in  CRM-12853
+      return $this->_pseudo_constant[$val];
     }
   }
 }

--- a/modules/views/components/civicrm.case.inc
+++ b/modules/views/components/civicrm.case.inc
@@ -1,0 +1,439 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.3                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * Build the $data array for CiviCase related tables
+ * Includes the following tables
+ * civicrm_case
+ */
+ 
+function _civicrm_case_data(&$data, $enabled) {
+
+  /**
+   *CiviCRM Campaign Base Table
+   */
+
+  $data['civicrm_case']['table']['group'] = t('CiviCRM Cases');
+
+  $data['civicrm_case']['table']['base'] = array(
+    // Governs the whole mozilla
+    'field' => 'id',
+    'title' => t('CiviCRM Cases'),
+    'help' => t("View displays CiviCRM Cases Data"),
+  );
+  
+  //TABLE JOINS FOR CIVICRM CASE GO HERE!
+  
+  $data['civicrm_case']['table']['join'] = array(
+    // Directly links to contact table.
+    'civicrm_case_contact' => array(
+      'left_field' => 'case_id',
+      'field' => 'id',
+    ),    
+	'civicrm_case_activity' => array(
+      'left_field' => 'case_id',
+      'field' => 'id',
+    ),	
+	'civicrm_relationship' => array(
+      'left_field' => 'case_id',
+      'field' => 'id',
+    ), 
+  );
+  
+  // Campaign ID
+  $data['civicrm_case']['id'] = array(
+    'title' => t('Case ID'),
+    'help' => t('The numeric ID of the case'),
+    'field' => array(
+      'handler' => 'views_handler_field_numeric',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+      'numeric' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  ); 
+  
+  // Case Type
+  $data['civicrm_case']['case_type'] = array(
+    'title' => t('Case Type'),
+    'real field' => 'case_type_id',
+    'help' => t('The Case Type'),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_pseudo_constant',
+      'click sortable' => TRUE,
+      'pseudo class' => 'CRM_Case_PseudoConstant',
+      'pseudo method' => 'caseType',
+	  'pseudo args' => array('Label', FALSE),
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_pseudo_constant',
+      'pseudo class' => 'CRM_Case_PseudoConstant',
+      'pseudo method' => 'caseType',
+	  'pseudo args' => array('Label', FALSE),
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+	  'pseudo args' => 'caseType',
+    ),
+  );
+  
+  //DISPLAY Name for the Contact (Full Name with Prefixes and Suffixes)
+  $data['civicrm_case']['subject'] = array(
+    'title' => t('Subject'),
+    'help' => t('A short description of the case.'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //CASE Start DATE
+  $data['civicrm_case']['start_date'] = array(
+    'title' => t('Start Date'),
+    'help' => t('The Case\'s Start Date'),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_datetime',
+      'click sortable' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_datetime',
+      'is date' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'civicrm_handler_sort_date',
+    ),
+    'argument' => array(
+      'handler' => 'date_views_argument_handler',
+      'empty field name' => t('Undated'),
+      'is date' => TRUE,
+    ),
+  );
+
+  civicrm_views_add_date_arguments($data['civicrm_case'], array(
+    'title' => 'Start Date',
+      'name' => 'start_date',
+    ));
+	
+  //CASE END DATE
+  $data['civicrm_case']['end_date'] = array(
+    'title' => t('End Date'),
+    'help' => t('The Case\'s End Date'),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_datetime',
+      'click sortable' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_datetime',
+      'is date' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'civicrm_handler_sort_date',
+    ),
+  );
+
+  civicrm_views_add_date_arguments($data['civicrm_case'], array(
+    'title' => 'End Date',
+      'name' => 'end_date',
+    ));
+	
+  //Case Details / Notes
+  $data['civicrm_case']['details'] = array(
+    'title' => t('Details'),
+    'help' => t('Details and Notes regarding the case.'),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_markup',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //Case Status
+  $data['civicrm_case']['status'] = array(
+    'title' => t('Case Status'),
+    'real field' => 'status_id',
+    'help' => t('The Status of this case'),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_pseudo_constant',
+      'click sortable' => TRUE,
+      'pseudo class' => 'CRM_Case_PseudoConstant',
+      'pseudo method' => 'caseStatus',
+	  'pseudo args' => array('Label', FALSE),
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_pseudo_constant',
+      'allow empty' => TRUE,
+      'pseudo class' => 'CRM_Case_PseudoConstant',
+      'pseudo method' => 'caseStatus',
+	  'pseudo args' => array('Label', FALSE),
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //Case is deleted
+  $data['civicrm_case']['is_deleted'] = array(
+    'title' => t('Is Deleted'),
+    'help' => t('If the current Case is deleted.'),
+    'field' => array(
+      'handler' => 'views_handler_field_boolean',
+      'click sortable' => TRUE,
+   ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_boolean_operator',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  ); 
+
+
+  //----------------------------------------------------------------
+  // CIVICRM Case Activities are here, base tabling it up.
+  //----------------------------------------------------------------
+
+  $data['civicrm_case_activity']['table']['group'] = t('CiviCRM Case Activity');
+
+  $data['civicrm_case_activity']['table']['base'] = array(
+    // Governs the whole mozilla
+    'field' => 'id',
+    'title' => t('CiviCRM Case Activity'),
+    'help' => t("View displays CiviCRM Case Activities"),
+  );
+  
+  // Explain how this table joins to others.
+  $data['civicrm_case_activity']['table']['join'] = array(
+    // Directly links to activity table.
+    'civicrm_activity' => array(
+      'left_field' => 'id',
+      'field' => 'activity_id',
+    ),
+	'civicrm_case' => array(
+      'left_field' => 'id',
+      'field' => 'case_id',
+    ),
+  );
+  
+  //CiviCRM Case Activity - FIELDS
+
+  //Numeric Case Activity ID
+  $data['civicrm_case_activity']['id'] = array(
+    'title' => t('Case Activity ID'),
+    'help' => t('The numeric ID of the Case Activity'),
+    'field' => array(
+      'handler' => 'views_handler_field_numeric',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+      'numeric' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //Numeric Case ID
+  $data['civicrm_case_activity']['case_id'] = array(
+    'title' => t('Case ID'),
+    'help' => t('The numeric ID of the Case'),
+    'relationship' => array(
+      'base' => 'civicrm_case',
+                                                                             'field' => 'case_id',
+                                                                             'left_field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('CiviCRM Case, with custom fields'),
+    ),
+  );
+  
+  //Numeric Activity ID
+  $data['civicrm_case_activity']['activity_id'] = array(
+    'title' => t('Case Activity\'s Activity ID'),
+    'help' => t('The numeric ID of the Activity of the Case'),
+    'field' => array(
+      'handler' => 'views_handler_field_numeric',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+      'numeric' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+    'relationship' => array(
+      'base' => 'civicrm_activity',
+      'field' => 'activity_id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('CiviCRM Activity, with custom fields'),
+    ),
+  );
+
+  //----------------------------------------------------------------
+  // CIVICRM Case Contacts are here, base tabling it up.
+  //----------------------------------------------------------------
+
+  $data['civicrm_case_contact']['table']['group'] = t('CiviCRM Case Contact');
+
+  $data['civicrm_case_contact']['table']['base'] = array(
+    // Governs the whole mozilla
+    'field' => 'id',
+    'title' => t('CiviCRM Case Contact'),
+    'help' => t("View displays CiviCRM Case Contact"),
+  );
+    
+  // Explain how this table joins to others.
+  $data['civicrm_case_contact']['table']['join'] = array(
+    // Directly links to case table.
+	'civicrm_case' => array(
+      'left_field' => 'id',
+      'field' => 'case_id',
+    ),
+  );
+  
+  // display user fields in Case Contacts view
+  $data['civicrm_case_contact']['table']['join']['users'] = array(
+    'left_table' => 'civicrm_uf_match',
+    'left_field' => 'contact_id',
+    'field' => 'contact_id',
+  );
+  $data['users']['table']['join']['civicrm_case_contact'] = array(
+    'left_table' => 'civicrm_uf_match',
+    'left_field' => 'uf_id',
+    'field' => 'uid',
+  );
+  //Display Case Contacts in User Views
+  $data['civicrm_uf_match']['table']['join']['civicrm_case_contact'] = array(
+    'left_field' => 'contact_id',
+    'field' => 'contact_id',
+  );
+ 
+  //CiviCRM Case Contacts - FIELDS
+
+  //Numeric Case Contact ID
+  $data['civicrm_case_contact']['id'] = array(
+    'title' => t('Case Contact ID'),
+    'help' => t('The numeric ID of the Case Contact'),
+    'field' => array(
+      'handler' => 'views_handler_field_numeric',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+      'numeric' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //Numeric Case ID
+  $data['civicrm_case_contact']['case_id'] = array(
+    'title' => t('Case ID'),
+    'help' => t('The numeric ID of the Case'),
+    'relationship' => array(
+      'base' => 'civicrm_case',
+                                                                             'field' => 'case_id',
+                                                                             'left_field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('CiviCRM Case, with custom fields'),
+    ),
+  );
+
+  //Numeric Contact ID
+  $data['civicrm_case_contact']['contact_id'] = array(
+    'title' => t('Case Contact\'s Contact ID'),
+    'help' => t('The numeric ID of the Contact of the Case'),
+    'field' => array(
+      'handler' => 'views_handler_field_numeric',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+      'numeric' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+    'relationship' => array(
+      'base' => 'civicrm_contact',
+      'field' => 'contact_id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('CiviCRM Contact, with custom fields'),
+    ),
+  );
+  
+}
+

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -92,6 +92,11 @@ function _civicrm_core_data(&$data, $enabled) {
       'left_field' => 'contact_id',
       'field' => 'id',
     ),
+    // Links to case contacts
+      'civicrm_case_contact' => array(
+      'left_field' => 'contact_id',
+      'field' => 'id',
+     ),
   );
 
   // For other base tables, explain how we join -
@@ -1488,6 +1493,7 @@ function _civicrm_core_data(&$data, $enabled) {
       'click sortable' => TRUE,
       'pseudo class' => 'CRM_Core_PseudoConstant',
       'pseudo method' => 'activityType',
+      'pseudo args' => array(TRUE, TRUE), // Include cases (if CiviCase is enabled)
     ),
     'argument' => array(
       'handler' => 'views_handler_argument',
@@ -1497,6 +1503,7 @@ function _civicrm_core_data(&$data, $enabled) {
       'allow empty' => TRUE,
       'pseudo class' => 'CRM_Core_PseudoConstant',
       'pseudo method' => 'activityType',
+      'pseudo args' => array(TRUE, TRUE),
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
@@ -1974,6 +1981,10 @@ function _civicrm_core_data(&$data, $enabled) {
       'handler' => 'views_handler_relationship',
       'label' => t('CiviCRM Contact A'),
     ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
   );
 
   $data['civicrm_relationship']['contact_id_b'] = array(
@@ -1992,6 +2003,10 @@ function _civicrm_core_data(&$data, $enabled) {
       'base field' => 'id',
       'handler' => 'views_handler_relationship',
       'label' => t('CiviCRM Contact B'),
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
     ),
   );
 
@@ -2084,6 +2099,32 @@ function _civicrm_core_data(&$data, $enabled) {
       'handler' => 'civicrm_handler_field_link_relationship',
     ),
   );
+
+  // Case ID for CiviCase
+  if (isset($enabled['CiviCase'])) {
+	  $data['civicrm_relationship']['case_id'] = array(
+		'title' => t('Case ID'),
+		'real field' => 'case_id',
+		'help' => t('The case ID of this relationship'),
+		'field' => array(
+		  'handler' => 'views_handler_field',
+		  'click sortable' => FALSE,
+		),
+		'argument' => array(
+		  'handler' => 'views_handler_argument',
+		),
+		'filter' => array(
+		  'handler' => 'views_handler_filter_numeric',
+		  'allow empty' => TRUE,
+		),
+		'relationship' => array(
+		  'base' => 'civicrm_case',
+		  'field' => 'case_id',
+		  'handler' => 'views_handler_relationship',
+		  'label' => t('CiviCRM Case'),
+		),
+	  );
+  }
 
   /*
      * Add support for CivicRM groups table


### PR DESCRIPTION
@Kurund Jalmi 

Please see notes add:
http://issues.civicrm.org/jira/browse/CRM-12853

I removed the bugfix mentioned in Note 1, as the code has changed in 4.4, and the bug might have been removed.
The test links still work with 4.4 code:

 http://viazni.pakalennie.de/cases
 http://viazni.pakalennie.de/activities
 http://viazni.pakalennie.de/relationships

CiviCase also appears in the menus for setting up views, but I can't completely check all the configuration details again at the moment.

As an aside dlats@netzero.net wrote about my patch:
"Thanks again for the patch to _civicrm_core_data (activity_id). In looking through your code, I noticed that you specified joins to civicrm_activity and civicrm_contacts as well as adding a relationship to the fields civicrm_case_activity.activity_id and civicrm_case_contact.contact_id. I was able to use just the relationships with out specifying the joins. It seems redundant."

So it is quite possible that some code is redundant, however I am weary to remove anything, as it seems to work.
