### PR TITLE
-- CRM-13339 Notice fixes and fixes related to the location handler file

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_location.inc
+++ b/modules/views/civicrm/civicrm_handler_field_location.inc
@@ -39,7 +39,7 @@ class civicrm_handler_field_location extends civicrm_handler_field {
         return;
       }
       require_once 'CRM/Core/PseudoConstant.php';
-      self::$_locationTypes = CRM_Core_PseudoConstant::locationType();
+      self::$_locationTypes = CRM_Core_PseudoConstant::get($this->definition['dao class'], 'location_type_id');
       self::$_locationOps = array(0 => 'AND', 1 => 'OR');
     }
   }

--- a/modules/views/civicrm/civicrm_handler_field_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_field_pseudo_constant.inc
@@ -47,9 +47,13 @@ class civicrm_handler_field_pseudo_constant extends views_handler_field {
     if (isset($this->definition['pseudo args']) && is_array($this->definition['pseudo args'])) {
       $pseudo_args = $this->definition['pseudo args'];
     }
-    else {
+    elseif (isset($this->definition['dao class']) && isset($this->definition['real field'])) {
       $pseudo_args = array($this->definition['dao class'], $this->definition['real field']);
     }
+    else {
+      $pseudo_args = array();
+    }
+      
 
     // Include and call the Pseudo Class method
     $this->_pseudo_constant = call_user_func_array($this->definition['pseudo class'] . "::" . $this->definition['pseudo method'], $pseudo_args);

--- a/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
@@ -46,9 +46,13 @@ class civicrm_handler_filter_pseudo_constant extends views_handler_filter_in_ope
     if (isset($this->definition['pseudo args']) && is_array($this->definition['pseudo args'])) {
       $pseudo_args = $this->definition['pseudo args'];
     }
-    else {
+    elseif (isset($this->definition['dao class']) && isset($this->definition['real field'])) {
       $pseudo_args = array($this->definition['dao class'], $this->definition['real field']);
     }
+    else {
+      $pseudo_args = array();
+    }
+
     require_once str_replace('_', DIRECTORY_SEPARATOR, $this->definition['pseudo class']) . '.php';
     // Include and call the Pseudo Class method
     $this->_pseudo_constant = call_user_func_array($this->definition['pseudo class'] . "::" . $this->definition['pseudo method'], $pseudo_args);

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -760,6 +760,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_address',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Address',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -780,6 +781,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_address',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Address',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -800,6 +802,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_address',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Address',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -820,6 +823,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_address',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Address',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -863,6 +867,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_address',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Address',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -883,6 +888,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_address',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Address',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -903,6 +909,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_address',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Address',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -973,6 +980,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_address',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Address',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -1116,6 +1124,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_email',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Email',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',
@@ -1258,6 +1267,7 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'civicrm_handler_field_phone',
       'click sortable' => TRUE,
+      'dao class' => 'CRM_Core_DAO_Phone',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument_string',


### PR DESCRIPTION
---
- CRM-13339: CRM_Core_PseudoConstant warnings
  http://issues.civicrm.org/jira/browse/CRM-13339

Made some notice fixes. The location fields address, email and phone were using a handler that extends a common location handler civicrm_handler_field_location. This file was still calling the old CRM_Core_PseudoConstant::locationType() function. Made fixes for that too.
