### PR TITLE
CRM-13388 - Fix upgrade error due to undefined column, "description"

### DIFF
--- a/civicrm_user.inc
+++ b/civicrm_user.inc
@@ -132,7 +132,7 @@ function civicrm_user_categories() {
     return;
   }
 
-  $allUFGroups = CRM_Core_BAO_UFGroup::getModuleUFGroup('User Account');
+  $allUFGroups = CRM_Core_BAO_UFGroup::getModuleUFGroup('User Account', 0, TRUE, CRM_Core_Permission::VIEW, array('id', 'name', 'title', 'is_active'));
   $ufGroups = array();
 
   $weight = 100;


### PR DESCRIPTION
---
- CRM-13388: Drush upgrade fails due to missing column, civicrm_uf_group.description
  http://issues.civicrm.org/jira/browse/CRM-13388
