### PR TITLE
Exposes all the fields in the civicrm_mailing table to drupal views

### DIFF
--- a/modules/views/components/civicrm.mail.inc
+++ b/modules/views/components/civicrm.mail.inc
@@ -28,7 +28,7 @@
  * Includes the following tables
  * civicrm_mailing
  * civicrm_mailing_event_queue
- * civicrm_mailing_header
+ * civicrm_mailing_header **NB mailing_component table now aliased as mailing_header
  * civicrm_mailing_job
  * civicrm_mailing_event_forward
  * civicrm_mailing_event_trackable_url_open
@@ -62,9 +62,8 @@ function _civicrm_mail_data(&$data, $enabled) {
     ),
   );
 
-
-
   //CiviCRM Mailing - FIELDS
+  //Fields are specified in the order they appear in the database table
   // expose the ID to Views to allow users to drill down to a specific mailing.
   $data['civicrm_mailing']['id'] = array(
     'title' => t('ID'),
@@ -75,8 +74,152 @@ function _civicrm_mail_data(&$data, $enabled) {
     'field' => array(
       'handler' => 'views_handler_field',
     ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
   );
-
+  
+  //expose the domain_id to Views to allow users to specify a domain.
+  $data['civicrm_mailing']['domain_id'] = array(
+    'title' => t('Domain ID'),
+    'help' => t('The mailing\'s Domain ID in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //expose the header_id to Views to choose mailings based on a header type
+  $data['civicrm_mailing']['header_id'] = array(
+    'title' => t('Header ID'),
+    'help' => t('The mailing\'s Header ID in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //expose the footer_id to Views to choose mailings based on a footer type
+  $data['civicrm_mailing']['footer_id'] = array(
+    'title' => t('Footer ID'),
+    'help' => t('The mailing\'s Footer ID in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //expose the reply_id to Views to choose mailings based on a reply type
+  //Or maybe this is to drill down to a single reply
+  $data['civicrm_mailing']['reply_id'] = array(
+    'title' => t('Reply ID'),
+    'help' => t('The mailing\'s Reply ID in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //expose the unsubscribe_id to Views to choose mailings based on an unsubscribe type
+  //Or maybe this is to drill down to a single unsubscribe request
+  $data['civicrm_mailing']['unsubscribe_id'] = array(
+    'title' => t('Unsubscribe ID'),
+    'help' => t('The mailing\'s Unsubscribe ID in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //expose the resubscribe_id to Views to choose mailings based on an resubscribe type
+  //Or maybe this is to drill down to a single rensubscribe request
+  $data['civicrm_mailing']['resubscribe_id'] = array(
+    'title' => t('Resubscribe ID'),
+    'help' => t('The mailing\'s Resubscribe ID in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //expose the optout_id to Views to choose mailings based on an optout type
+  //Or maybe this is to drill down to a single optout request
+  $data['civicrm_mailing']['optout_id'] = array(
+    'title' => t('Optout ID'),
+    'help' => t('The mailing\'s Optout ID in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
   //Mailing Name
   $data['civicrm_mailing']['name'] = array(
     'title' => t('Name'),
@@ -95,6 +238,66 @@ function _civicrm_mail_data(&$data, $enabled) {
       'allow empty' => TRUE,
       'pseudo class' => 'CRM_Mailing_PseudoConstant',
       'pseudo method' => 'completed',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //From Name
+  $data['civicrm_mailing']['from_name'] = array(
+    'title' => t('From Name'),
+    'help' => t('From Name line of the mailing'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //Mailing From e-mail
+  $data['civicrm_mailing']['from_email'] = array(
+    'title' => t('From Email'),
+    'help' => t('From Email of the mailing'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //Mailing reply to e-mail
+  $data['civicrm_mailing']['replyto_email'] = array(
+    'title' => t('Reply to Email'),
+    'help' => t('Reply Email of the mailing'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
@@ -160,45 +363,7 @@ function _civicrm_mail_data(&$data, $enabled) {
       'handler' => 'views_handler_sort',
     ),
   );
-
-  //Mailing From e-mail
-  $data['civicrm_mailing']['from_email'] = array(
-    'title' => t('From Email'),
-    'help' => t('From Email of the mailing'),
-    'field' => array(
-      'handler' => 'views_handler_field',
-      'click sortable' => TRUE,
-    ),
-    'argument' => array(
-      'handler' => 'views_handler_argument_string',
-    ),
-    'filter' => array(
-      'handler' => 'views_handler_filter_string',
-      'allow empty' => TRUE,
-    ),
-    'sort' => array(
-      'handler' => 'views_handler_sort',
-    ),
-  );
-  //Mailing reply to e-mail
-  $data['civicrm_mailing']['replyto_email'] = array(
-    'title' => t('Reply to Email'),
-    'help' => t('Reply Email of the mailing'),
-    'field' => array(
-      'handler' => 'views_handler_field',
-      'click sortable' => TRUE,
-    ),
-    'argument' => array(
-      'handler' => 'views_handler_argument_string',
-    ),
-    'filter' => array(
-      'handler' => 'views_handler_filter_string',
-      'allow empty' => TRUE,
-    ),
-    'sort' => array(
-      'handler' => 'views_handler_sort',
-    ),
-  );
+  
   //Does the mailng track click throughs
   $data['civicrm_mailing']['url_tracking'] = array(
     'title' => t('Track URLs?'),
@@ -217,6 +382,47 @@ function _civicrm_mail_data(&$data, $enabled) {
       'handler' => 'views_handler_sort',
     ),
   );
+  
+  //forward_replies
+  //Should we forward replies back to the author?
+  $data['civicrm_mailing']['forward_replies'] = array(
+    'title' => t('Forward Replies?'),
+    'help' => t('Should we forward replies back to the author?'),
+    'field' => array(
+      'handler' => 'views_handler_field_boolean',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_boolean_operator',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //auto_responder 
+  //Should we enable the auto-responder?
+  $data['civicrm_mailing']['auto_responder'] = array(
+    'title' => t('Auto Responder?'),
+    'help' => t('Is the auto responder enabled for this mailing?'),
+    'field' => array(
+      'handler' => 'views_handler_field_boolean',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_boolean_operator',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
   //Does the e-mail track opens
   $data['civicrm_mailing']['open_tracking'] = array(
     'title' => t('Track Opens?'),
@@ -248,6 +454,224 @@ function _civicrm_mail_data(&$data, $enabled) {
     ),
     'filter' => array(
       'handler' => 'views_handler_filter_boolean_operator',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //msg_template_id 
+  //FK to the message template
+  $data['civicrm_mailing']['msg_template_id'] = array(
+    'title' => t('Messaage Template ID'),
+    'help' => t('The mailing\'s Message Template ID in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //override_verp 
+  //Should we overrite VERP address in Reply-To
+  $data['civicrm_mailing']['is_completed'] = array(
+    'title' => t('Overrite VERP?'),
+    'help' => t('Should we overrite VERP address in Reply-To?'),
+    'field' => array(
+      'handler' => 'views_handler_field_boolean',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_boolean_operator',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //created_id 
+  //FK to Contact ID who first created this mailing
+  $data['civicrm_mailing']['created_id'] = array(
+    'title' => t('Creator ID'),
+    'help' => t('The user ID of the mailing\'s creator in the database.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //created_date	 
+  $data['civicrm_mailing']['created_date'] = array(
+    'title' => t('Created Date'),
+    'help' => t('The Mailing\'s Created Date'),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_datetime',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_date',
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_datetime',
+      'is date' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'civicrm_handler_sort_date',
+    ),
+  );
+
+  civicrm_views_add_date_arguments($data['civicrm_mailing'], array(
+    'title' => 'Created Date',
+      'name' => 'created_date',
+    ));
+  
+  //scheduled_id	
+  
+  //scheduled_date	
+  //Dealt with below: see $data['civicrm_mailing_job']['scheduled_date']
+  
+  //approver_id	
+  // FK to Contact ID who approved this mailing
+  $data['civicrm_mailing']['approver_id'] = array(
+    'title' => t('Approver ID'),
+    'help' => t('The database ID of the user that approved mailing.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //approval_date	
+  // Date and time this mailing was approved.
+  $data['civicrm_mailing']['approval_date'] = array(
+    'title' => t('Approval Date'),
+    'help' => t('The Mailing\'s Approval Date'),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_datetime',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_date',
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_datetime',
+      'is date' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'civicrm_handler_sort_date',
+    ),
+  );
+
+  civicrm_views_add_date_arguments($data['civicrm_mailing'], array(
+    'title' => 'Approval Date',
+      'name' => 'approval_date',
+    ));
+    
+  //approval_status_id
+  //Based on an option value. This value is an integer
+  //Can we link the integer to the option value in the display?
+  $data['civicrm_mailing']['approver_id'] = array(
+    'title' => t('Approval Status ID'),
+    'help' => t('The approval status ID for the mailing.'),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'field' => array(
+      'handler' => 'views_handler_field',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //approval_note
+  $data['civicrm_mailing']['approval_note'] = array(
+    'title' => t('Approval Note'),
+    'help' => t('Note behind the decision.'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+
+  //Is the mailing archived
+  $data['civicrm_mailing']['is_archived'] = array(
+    'title' => t('Archived?'),
+    'help' => t('Is the mailing archived?'),
+    'field' => array(
+      'handler' => 'views_handler_field_boolean',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_boolean_operator',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  //Is the mailing publicly visible or private
+  //The table has this as an ENUM field
+  //Might need to work on the 'handler' options for this field as if you
+  //want this to work as a filter, you need to provide the string
+  $data['civicrm_mailing']['visibility'] = array(
+    'title' => t('Visibility'),
+    'help' => t('Is the mailing visible online to everyone?'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
@@ -749,10 +1173,10 @@ function _civicrm_mail_data(&$data, $enabled) {
     ),
   );
 
-
+  //Unsubscribe group of options
   $data['civicrm_mailing_event_unsubscribe']['table']['group'] = ts('CiviCRM Mailing Unsubscribe');
 
-  $data['civicrm_mailing_event_unsubcribe']['table']['join'] = array(
+  $data['civicrm_mailing_event_unsubscribe']['table']['join'] = array(
     // link to civicrm_mailing through civicrm_mailing_event_queue
     'civicrm_mailing' => array(
       'left_table' => 'civicrm_mailing_event_queue',
@@ -793,6 +1217,47 @@ function _civicrm_mail_data(&$data, $enabled) {
     'filter' => array(
       'handler' => 'views_handler_filter_numeric',
       'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //Remaining tables in civicrm_mailing_event_unsubscribe:
+  //event_queue_id FK to EventQueue	
+  $data['civicrm_mailing_event_unsubscribe']['event_queue_id'] = array(
+    'title' => t('Event Queue ID'),
+    'help' => t('The event queue ID of the unsubscribe record'),
+    'field' => array(
+      'handler' => 'views_handler_field_numeric',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+      'numeric' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
+  //org_unsubscribe Unsubscribe at org- or group-level
+  $data['civicrm_mailing_event_unsubscribe']['org_unsubscribe'] = array(
+    'title' => t('Unsubscribe at organisation or group level?'),
+    'help' => t('Did the unsubscription happen at organisation or group level?'),
+    'field' => array(
+      'handler' => 'views_handler_field_boolean',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_boolean_operator',
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',


### PR DESCRIPTION
More or less copied and pasted the examples for other rows that are currently
exposed to views to add all the other rows in the table.

Some work could be done on the user experience for using some of the more
obscure fields, but it should give a views user the ability to use many
more fields.

Don't have a specific ticket to commit this against sorry!
