### PR TITLE
CRM-13589 - civicrm_member_roles_sync_user called when it should not be

### DIFF
--- a/modules/civicrm_member_roles/civicrm_member_roles.module
+++ b/modules/civicrm_member_roles/civicrm_member_roles.module
@@ -104,10 +104,7 @@ function civicrm_member_roles_sync_user($account) {
   if (!civicrm_initialize()) {
     return;
   }
-  if (
-    variable_get('civicrm_member_roles_sync_method', 0) == 0 ||
-    variable_get('civicrm_member_roles_sync_method', 0) == 3
-  ) {
+  if (variable_get('civicrm_member_roles_sync_method', 0) == 0) {
     _civicrm_member_roles_sync($account->uid);
   }
 }


### PR DESCRIPTION
http://issues.civicrm.org/jira/browse/CRM-13589
