### PR TITLE
Implicitly join civicrm_contributions to civicrm_contacts

### DIFF
--- a/modules/views/components/civicrm.contribute.inc
+++ b/modules/views/components/civicrm.contribute.inc
@@ -57,7 +57,14 @@ function _civicrm_contribute_data(&$data, $enabled) {
     'left_field' => 'id',
     'field' => 'contribution_recur_id',
   );
+  
   //TABLE JOINS FOR CIVICRM CONTRIBUTIONS GO HERE!
+  
+  $data['civicrm_contribution']['table']['join']['civicrm_contact'] = array(
+    'left_table' => 'civicrm_contact',
+    'left_field' => 'id',
+    'field' => 'contact_id',
+  );
 
   $data['civicrm_contribution']['table']['join']['civicrm_participant'] = array(
     'left_table' => 'civicrm_participant_payment',

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -131,14 +131,6 @@ function _civicrm_core_data(&$data, $enabled) {
     'sort' => array(
       'handler' => 'views_handler_sort',
     ),
-    'relationship' => array(
-      'base' => 'civicrm_contribution',
-      'title' => 'Contribution Records',
-      'left_field' => 'contact_id',
-      'field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Contributions'),
-    ),
   );
 
   $data['civicrm_contact']['relationship_id_a'] = array(


### PR DESCRIPTION
Also fixes bug in removed relationship, where the join was specified on the wrong fields.
