### PR TITLE
CRM-12110 fix - Drupal Views: custom fields on address do not work

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -317,9 +317,12 @@ function civicrm_views_custom_data_cache(&$data, $entity_type, $groupID, $subTyp
     case "Individual":
     case "Household":
     case "Organization":
-    case "Address":
     case "Group":
       $jointable = 'civicrm_contact';
+      break;
+
+    case "Address":
+      $jointable = 'civicrm_address';
       break;
 
     case "Event":

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -256,6 +256,7 @@ function _civicrm_core_data(&$data, $enabled) {
     // The item it appears as on the UI,
     'title' => t('Prefix'),
     // The help that appears on the UI,
+    'real field' => 'prefix_id',
     'help' => t('Prefix'),
     'field' => array(
       'handler' => 'civicrm_handler_field_pseudo_constant',
@@ -279,6 +280,7 @@ function _civicrm_core_data(&$data, $enabled) {
     // The item it appears as on the UI,
     'title' => t('Suffix'),
     // The help that appears on the UI,
+    'real field' => 'suffix_id',
     'help' => t('Suffix'),
     'field' => array(
       'handler' => 'civicrm_handler_field_pseudo_constant',


### PR DESCRIPTION
Also in addition it contains a fix for fatal error reproduced on uninstalling/disabling Views module or simply run any webtest on Views installed setup.
