### PR TITLE
fixes for url alias in civicrmtheme module, CRM-13677

### DIFF
--- a/modules/civicrmtheme/civicrmtheme.module
+++ b/modules/civicrmtheme/civicrmtheme.module
@@ -118,8 +118,10 @@ function civicrmtheme_custom_theme() {
   $args = explode('/', $_GET['q']);
   $path = implode('/', $args);
 
+  $menuPath = explode('?', $path);
+
   // Get the menu for above URL.
-  $item = CRM_Core_Menu::get($path);
+  $item = CRM_Core_Menu::get($menuPath[0]);
 
   // Check for public pages
   // If public page and civicrm public theme is set, apply civicrm public theme


### PR DESCRIPTION
---
- CRM-13677: Drupal 7 - civicrmtheme can't differentiate between public & admin pages if url aliasing is on
  http://issues.civicrm.org/jira/browse/CRM-13677
