### PR TITLE
Fix for retrieving Cms user of the participant

### DIFF
--- a/modules/civicrm_rules/civicrm_rules.participant-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.participant-eval.inc
@@ -91,7 +91,7 @@ LIMIT 1";
  */
 function civicrm_rules_events_argument_civicrm_contactID_load_user($entityobj) {
   require_once 'api/api.php';
-  $contact = civicrm_api('UFMatch', 'get', array('version' => 3, 'contact_id' => $entityobj->contact_id, 'sequential' => 1));
+  $contact = civicrm_api('UFMatch', 'get', array('version' => 3, 'contact_id' => $entityobj['participant']->contact_id, 'sequential' => 1));
   if (!empty($contact) && is_numeric($contact['values'][0]['uf_id'])) {
     return $contact['values'][0]['uf_id'];
   }


### PR DESCRIPTION
This is a fix for data selector for user in rules not retrieving the user of the participant contact.
