### PR TITLE
Crm 14007 - update views for activity contact restructure

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -5398,7 +5398,6 @@ function civicrm_views_handlers() {
     'handlers' =>
     //FIELD HANDLAAARRRRS! Field Handlers!
     array(
-      // LINK FIELDS GO HERE
       'civicrm_handler_field_link_contact' => array(
         'parent' => 'views_handler_field',
       ),
@@ -5423,6 +5422,9 @@ function civicrm_views_handlers() {
       'civicrm_handler_field_link_pcp' => array(
         'parent' => 'views_handler_field',
       ),
+      'civicrm_handler_field_pseudo_constant' => array(
+        'parent' => 'views_handler_field',
+      ),
       'civicrm_handler_field_gender' => array(
         'parent' => 'views_handler_field',
       ),
@@ -5441,6 +5443,7 @@ function civicrm_views_handlers() {
       'civicrm_handler_field_country' => array(
         'parent' => 'views_handler_field',
       ),
+
       'civicrm_handler_field_county' => array(
         'parent' => 'views_handler_field',
       ),
@@ -5476,6 +5479,12 @@ function civicrm_views_handlers() {
       ),
       'civicrm_handler_field_contribution_status' => array(
         'parent' => 'views_handler_field',
+      ),
+      'civicrm_handler_field' => array(
+        'parent' => 'views_handler_field',
+      ),
+      'civicrm_handler_field_activity' => array(
+        'parent' => 'civicrm_handler_field',
       ),
       'civicrm_handler_field_activity_status' => array(
         'parent' => 'views_handler_field',
@@ -5533,6 +5542,9 @@ function civicrm_views_handlers() {
       ),
       'civicrm_handler_field_file' => array(
         'parent' => 'views_handler_field',
+      ),
+      'civicrm_handler_filter_pseudo_constant' => array(
+        'parent' => 'views_handler_filter_in_operator',
       ),
       //FILTER HANDDLEAARRRS! Filter Handlers!
       'civicrm_handler_filter_datetime' => array(

--- a/modules/views/civicrm/civicrm_handler_field_activity.inc
+++ b/modules/views/civicrm/civicrm_handler_field_activity.inc
@@ -1,9 +1,7 @@
 <?php
-// $Id$
-
 /*
  +--------------------------------------------------------------------+
- | CiviCRM version 4.4                                                |
+ | CiviCRM version 4.4                                               |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM.                                    |
  |                                                                    |
@@ -26,32 +24,96 @@
 */
 
 /**
- * Field handler to provide acess control for the activity type field (which is a lookup)
+ * Field handler for activity contact field
  *
  * @ingroup civicrm_field_handlers
  */
 class civicrm_handler_field_activity extends civicrm_handler_field {
-  static $_activityTypes;
+  static $_recordType;
   function construct() {
-    if (!self::$_activityTypes) {
+    parent::construct();
+    if (!self::$_recordType) {
       if (!civicrm_initialize()) {
         return;
       }
-      require_once 'CRM/Core/PseudoConstant.php';
-      self::$_activityTypes = CRM_Core_PseudoConstant::activityType();
+      self::$_recordType = CRM_Core_PseudoConstant::get('CRM_Activity_BAO_ActivityContact', 'record_type_id');
     }
   }
 
-  function render($values) {
-    $lid = $values->{$this->field_alias};
-    if (empty($lid) ||
-      (int ) $lid <= 0
-    ) {
-      return NULL;
+  function option_definition() {
+    $options = parent::option_definition();
+    $options['record_type'] = array('default' => 0);
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    $recordTypes = array(0 => 'Any');
+    foreach (self::$_recordType as $id => $type) {
+      $recordTypes[$id] = $type;
+    }
+    $form['record_type'] = array(
+      '#type' => 'radios',
+      '#title' => 'Record type for this field',
+      '#options' => $recordTypes,
+      '#description' => t('Record type to be displayed for this field'),
+      '#default_value' => $this->options['record_type'],
+      '#fieldset' => 'record_type_choices',
+    );
+  }
+
+  /**
+   * Called to link activity contact with civicrm_contact in a query.
+   */
+  function query() {
+
+    // Figure out what base table
+    $table_data        = views_fetch_data($this->definition['base']);
+    $base_field        = empty($this->definition['base field']) ? $table_data['table']['base']['field'] : $this->definition['base field'];
+    $this->table_alias = $this->query->add_table($this->table, $this->relationship);
+
+    // Make sure the join to civicrm_contact form the civicrm_activity_contact table
+    // Otherwise the displayed field will always be the same as the base table's record
+    if ($this->table == 'civicrm_activity_contact' && isset($this->view->query->table_queue[$this->table_alias]['join']->field)) {
+      $this->view->query->table_queue[$this->table_alias]['join']->field = $this->definition['relationship field'];
     }
 
-    return self::$_activityTypes[$values->{$this->field_alias}];
+    $def = $this->definition;
+
+    $leftField         = $this->definition['base'] == 'civicrm_activity_contact' ? $this->field : $this->definition['other_field'];
+    $def['table']      = $this->definition['base'];
+    $def['field']      = $this->definition['base field'];
+    $def['left_table'] = $this->table_alias;
+    $def['left_field'] = $leftField;
+    if (!empty($this->options['required'])) {
+      $def['type'] = 'INNER';
+    }
+
+    if (!empty($def['join_handler']) && class_exists($def['join_handler'])) {
+      $join = new $def['join_handler'];
+    }
+    else {
+      $join = new views_join();
+    }
+
+    $join->definition = $def;
+    $join->construct();
+    $join->adjusted = TRUE;
+
+    // Add a join condition to the on clause to narrow down the relationship type shown
+    if (isset($this->options['record_type']) && $this->options['record_type']) {
+      $this->query->table_queue[$this->table_alias]['join']->extra[] = array(
+        'value' => $this->options['record_type'],
+        'numeric' => TRUE,
+        'field' => 'record_type_id',
+        'operator' => '=',
+      );
+    }
+
+    // use a short alias for this:
+    $alias = $def['table'] . '_' . $this->table;
+
+    $this->alias = $this->query->add_relationship($alias, $join, $this->definition['base'], $this->relationship);
   }
 }
-
 

--- a/modules/views/civicrm/civicrm_handler_field_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_field_pseudo_constant.inc
@@ -1,0 +1,69 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.4                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/*
+ * Developed by Jim Taylor.
+ *
+ * civicrm_handler_field_pseudo_constant.inc
+ * Display's Pseudo Constant after grabbing the label from the database
+ *
+ */
+class civicrm_handler_field_pseudo_constant extends views_handler_field {
+  public $_pseudo_constant;
+
+  function construct() {
+    parent::construct();
+    if (!civicrm_initialize() ||
+      !isset($this->definition['pseudo class']) ||
+      !isset($this->definition['pseudo method'])
+    ) {
+      return;
+    }
+
+    // Load pseudo arguments if passed as array from hook_views_data
+    if (isset($this->definition['pseudo args']) && is_array($this->definition['pseudo args'])) {
+      $pseudo_args = $this->definition['pseudo args'];
+    }
+    elseif (isset($this->definition['dao class']) && isset($this->definition['real field'])) {
+      $pseudo_args = array($this->definition['dao class'], $this->definition['real field']);
+    }
+    else {
+      $pseudo_args = array();
+    }
+
+
+    // Include and call the Pseudo Class method
+    $this->_pseudo_constant = call_user_func_array($this->definition['pseudo class'] . "::" . $this->definition['pseudo method'], $pseudo_args);
+  }
+
+  function render($values) {
+    if (!empty($values->{$this->field_alias})) {
+      $val = $values->{$this->field_alias};
+      $val = str_replace("\x01", '', $val); // TODO This fix should be replaced as described in  CRM-12853
+      return $this->_pseudo_constant[$val];
+    }
+  }
+}
+

--- a/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
@@ -1,0 +1,72 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.4                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+
+/*
+ * Developed by Jim Taylor.
+ * CiviCRM Views Integration
+ *
+ * civicrm_handler_filter_activity_status.inc
+ * Filters Activity Statuses, and is configured using the labels from the database
+ *
+ */
+class civicrm_handler_filter_pseudo_constant extends views_handler_filter_in_operator {
+  public $_pseudo_constant; function construct() {
+    parent::construct();
+    if (!civicrm_initialize() ||
+      !isset($this->definition['pseudo class']) ||
+      !isset($this->definition['pseudo method'])
+    ) {
+      return;
+    }
+
+    // Load pseudo arguments if passed as array from hook_views_data
+    if (isset($this->definition['pseudo args']) && is_array($this->definition['pseudo args'])) {
+      $pseudo_args = $this->definition['pseudo args'];
+    }
+    elseif (isset($this->definition['dao class']) && isset($this->definition['real field'])) {
+      $pseudo_args = array($this->definition['dao class'], $this->definition['real field']);
+    }
+    else {
+      $pseudo_args = array();
+    }
+
+    require_once str_replace('_', DIRECTORY_SEPARATOR, $this->definition['pseudo class']) . '.php';
+    // Include and call the Pseudo Class method
+    $this->_pseudo_constant = call_user_func_array($this->definition['pseudo class'] . "::" . $this->definition['pseudo method'], $pseudo_args);
+  }
+
+  function get_value_options() {
+    if (!isset($this->value_options)) {
+      $this->value_title = $this->definition['title'];
+      $options = array();
+      foreach ($this->_pseudo_constant as $id => $name) {
+        $options[$id] = $name;
+      }
+      $this->value_options = $options;
+    }
+  }
+}
+

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -67,8 +67,8 @@ function _civicrm_core_data(&$data, $enabled) {
       'field' => 'id',
     ),
     // Directly links to activity.
-    'civicrm_activity' => array(
-      'left_field' => 'source_contact_id',
+    'civicrm_activity_contact' => array(
+      'left_field' => 'contact_id',
       'field' => 'id',
     ),
     // Directly links to membership.
@@ -529,27 +529,36 @@ function _civicrm_core_data(&$data, $enabled) {
     ),
   );
 
-  $data['civicrm_activity']['source_contact_id'] = array(
-    'title' => t('Source Contact'),
-    'help' => t('The contact who scheduled this activity'),
-    'relationship' => array(
-      'base' => 'civicrm_contact',
-      'field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Source Contact'),
-    ),
+  $data['civicrm_activity']['source_record_id'] = array(
+    'title' => t('Record Source'),
+    'real field' => 'source_record_id',
+    'help' => t('Source record activity'),
   );
 
-  $data['civicrm_activity']['source_record_id'] = array(
-    'title' => t('Source Record ID'),
-    'help' => t('The contact who made this activity'),
-    'relationship' => array(
-      'base' => 'civicrm_contact',
-      'field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Source Record Contact'),
-    ),
-  );
+  /*
+   * This block is commented out for two reasons:
+   *  1) The help text is misleading to users; source_record_id is NOT
+   *     "the contact who made this activity."
+   *  2) It doesn't work; the code attempts to join on the wrong table.
+   *
+   * TODO: Figure out how to tell Views to join to a table whose identity
+   *       isn't known yet. Because the details of the "parent" activity
+   *       reside in different tables depending on the value of
+   *       activity_type_id, Views needs to be told which table to
+   *       join to on the fly.
+   *
+   *  $data['civicrm_activity']['source_record_id'] = array(
+   *    'title' => t('Source Record ID'),
+   *    // 'help' => t('The contact who made this activity'),
+   *    'help' => t('The parent transaction (e.g. Contribution, Event Registration) if it is not an Activity.'),
+   *    'relationship' => array(
+   *      'base' => 'civicrm_contact',
+   *      'field' => 'id',
+   *      'handler' => 'views_handler_relationship',
+   *      'label' => t('CiviCRM Source Record Contact'),
+   *    ),
+   *  );
+   */
 
   //Activity Type
   $data['civicrm_activity']['activity_type'] = array(
@@ -557,15 +566,21 @@ function _civicrm_core_data(&$data, $enabled) {
     'real field' => 'activity_type_id',
     'help' => t('The Type of Activity'),
     'field' => array(
-      'handler' => 'civicrm_handler_field_activity_type',
+      'handler' => 'civicrm_handler_field_pseudo_constant',
       'click sortable' => TRUE,
+      'pseudo class' => 'CRM_Core_PseudoConstant',
+      'pseudo method' => 'activityType',
+      'pseudo args' => array(TRUE, TRUE), // Include cases (if CiviCase is enabled)
     ),
     'argument' => array(
       'handler' => 'views_handler_argument',
     ),
     'filter' => array(
-      'handler' => 'civicrm_handler_filter_activity_type',
+      'handler' => 'civicrm_handler_filter_pseudo_constant',
       'allow empty' => TRUE,
+      'pseudo class' => 'CRM_Core_PseudoConstant',
+      'pseudo method' => 'activityType',
+      'pseudo args' => array(TRUE, TRUE),
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
@@ -578,15 +593,19 @@ function _civicrm_core_data(&$data, $enabled) {
     'real field' => 'status_id',
     'help' => t('The Status of this Activity'),
     'field' => array(
-      'handler' => 'civicrm_handler_field_activity_status',
+      'handler' => 'civicrm_handler_field_pseudo_constant',
       'click sortable' => TRUE,
+      'pseudo class' => 'CRM_Core_PseudoConstant',
+      'pseudo method' => 'activityStatus',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument',
     ),
     'filter' => array(
-      'handler' => 'civicrm_handler_filter_activity_status',
+      'handler' => 'civicrm_handler_filter_pseudo_constant',
       'allow empty' => TRUE,
+      'pseudo class' => 'CRM_Core_PseudoConstant',
+      'pseudo method' => 'activityStatus',
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
@@ -599,15 +618,21 @@ function _civicrm_core_data(&$data, $enabled) {
     'real field' => 'priority_id',
     'help' => t('The Priority of this Activity'),
     'field' => array(
-      'handler' => 'civicrm_handler_field_priority',
+      'handler' => 'civicrm_handler_field_pseudo_constant',
       'click sortable' => TRUE,
+      'pseudo class' => 'CRM_Core_PseudoConstant',
+      'pseudo method' => 'get',
+      'dao class' => 'CRM_Activity_DAO_Activity',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument',
     ),
     'filter' => array(
-      'handler' => 'civicrm_handler_filter_priority',
+      'handler' => 'civicrm_handler_filter_pseudo_constant',
       'allow empty' => TRUE,
+      'pseudo class' => 'CRM_Core_PseudoConstant',
+      'pseudo method' => 'get',
+      'dao class' => 'CRM_Activity_DAO_Activity',
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
@@ -773,7 +798,7 @@ function _civicrm_core_data(&$data, $enabled) {
       'handler' => 'views_handler_sort',
     ),
   );
-  //BOOLEAN : IS A TEST ACTIVITY
+  //BOOLEAN : IS AUTO ACTIVITY
   $data['civicrm_activity']['is_auto'] = array(
     'title' => t('Is Automaticaly created'),
     'help' => t('Is the activity created by the system?'),
@@ -806,68 +831,127 @@ function _civicrm_core_data(&$data, $enabled) {
     'title' => t('Engagement level'),
     'help' => t('The Engagement Level of this Activity for this contact'),
     'field' => array(
-      'handler' => 'views_handler_field_numeric',
+      'handler' => 'civicrm_handler_field_pseudo_constant',
       'click sortable' => TRUE,
+      'pseudo class' => 'CRM_Campaign_PseudoConstant',
+      'pseudo method' => 'engagementLevel',
     ),
     'argument' => array(
       'handler' => 'views_handler_argument',
     ),
     'filter' => array(
-      'handler' => 'views_handler_filter_numeric',
+      'handler' => 'civicrm_handler_filter_pseudo_constant',
       'allow empty' => TRUE,
+      'pseudo class' => 'CRM_Campaign_PseudoConstant',
+      'pseudo method' => 'engagementLevel',
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
     ),
   );
 
+  // CRM-11488
+  $data['civicrm_activity']['is_current_revision'] = array(
+    'title' => t('Current Revision'),
+    'help' => t('Use to dedupe Civicase revisions'),
+    'field' => array(
+      'handler' => 'views_handler_field_boolean',
+      'click sortable' => TRUE,
+   ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_boolean_operator',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  $data['civicrm_activity']['is_deleted'] = array(
+    'title' => t('Is Deleted'),
+    'help' => t('If the current Activity is deleted. Also used to dedupe Civicase revisions'),
+    'field' => array(
+      'handler' => 'views_handler_field_boolean',
+      'click sortable' => TRUE,
+   ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_boolean_operator',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
 
+  // let's add activity contact table
+  $data['civicrm_activity_contact']['table']['group'] = t('CiviCRM Activity Contacts');
 
-  // CHILLING OUT AT THE CIVICRM_ACTIVTY_ASSIGNMENT TABLE
-
-  $data['civicrm_activity_assignment']['table']['group'] = t('CiviCRM Activity Assignments');
+  $data['civicrm_activity_contact']['table']['base'] = array(
+    'field' => 'id',
+    'title' => t('CiviCRM Activity Contacts'),
+    'help' => t("View displays CiviCRM Activity, with connection to contacts."),
+  );
 
   // Explain how this table joins to others.
-  $data['civicrm_activity_assignment']['table']['join'] = array(
-    // Directly links to event table
+  $data['civicrm_activity_contact']['table']['join'] = array(
+    // Directly links to activity table
     'civicrm_activity' => array(
       'left_field' => 'id',
       'field' => 'activity_id',
     ),
   );
 
-  $data['civicrm_activity_assignment']['assignee_contact_id'] = array(
-    'title' => t('Assignee Contact ID'),
-    'help' => t('The contact who is assigned the activity.'),
+  $data['civicrm_activity_contact']['contact_id'] = array(
+    'title' => t('Activity Contact ID'),
+    'real field' => 'contact_id',
+    'help' => t('The contact related to the activity.'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => FALSE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
     'relationship' => array(
       'base' => 'civicrm_contact',
-      'field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Assignee Contact ID'),
+      'base field' => 'id',
+      'handler' => 'civicrm_handler_field_activity',
+      'label' => t('CiviCRM Activity Contact ID'),
+      'relationship table' => 'civicrm_activity',
+      'relationship field' => 'activity_id',
+      'other_field' => 'contact_id',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
     ),
   );
 
-  // CHILLING OUT AT THE CIVICRM_ACTIVTY_ASSIGNMENT TABLE
-
-  $data['civicrm_activity_target']['table']['group'] = t('CiviCRM Activity Targets');
-
-  // Explain how this table joins to others.
-  $data['civicrm_activity_target']['table']['join'] = array(
-    // Directly links to event table
-    'civicrm_activity' => array(
-      'left_field' => 'id',
-      'field' => 'activity_id',
+  $data['civicrm_activity_contact']['record_type'] = array(
+    'title' => t('Record Type'),
+    'real field' => 'record_type_id',
+    'help' => t('Record type'),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_pseudo_constant',
+      'click sortable' => TRUE,
+      'pseudo class' => 'CRM_Core_PseudoConstant',
+      'pseudo method' => 'get',
+      'dao class' => 'CRM_Activity_DAO_ActivityContact',
     ),
-  );
-
-  $data['civicrm_activity_target']['target_contact_id'] = array(
-    'title' => t('Target Contact ID'),
-    'help' => t('The contact who is the activity\'s target.'),
-    'relationship' => array(
-      'base' => 'civicrm_contact',
-      'field' => 'id',
-      'handler' => 'views_handler_relationship',
-      'label' => t('CiviCRM Target Contact ID'),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_pseudo_constant',
+      'pseudo class' => 'CRM_Core_PseudoConstant',
+      'pseudo method' => 'get',
+      'dao class' => 'CRM_Activity_DAO_ActivityContact',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
     ),
   );
 


### PR DESCRIPTION
This is the drupal7 version of the code - it is not 'seemless' existing views with activity->contact relationships need to be edited & the fields, relationships, filters etc re-saved. I expect this is also required in d7
