### PR TITLE
CRM-14274 - Removed reference to API v2

### DIFF
--- a/modules/civicrm_group_roles/civicrm_group_roles.module
+++ b/modules/civicrm_group_roles/civicrm_group_roles.module
@@ -240,7 +240,6 @@ function civicrm_role_granted_by_other_group($contact_id, $rid, $group_id) {
   if (!civicrm_initialize()) {
     return;
   }
-  require_once 'api/v2/GroupContact.php';
   //get all the groups this contact belongs to
   $params = array('version' => '3', 'contact_id' => $contact_id);
   $result =  civicrm_api('group_contact','get',$params);


### PR DESCRIPTION
API v2 was removed in CiviCRM 4.4 but civicrm_group_roles.module still references api/v2.
