### PR TITLE
fix civicrm-sql-connect and civicrm-sql-query commands

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -1144,14 +1144,20 @@ function drush_civicrm_sqlconnect_validate() {
  * Implementation of command 'civicrm-sql-connect'
  */
 function drush_civicrm_sqlconnect() {
-  drush_sql_connect();
+  return drush_sql_connect();
+}
+
+/**
+ * Implements drush_post_COMMAND hook
+ */
+function drush_civicrm_post_civicrm_sql_connect() {
   _civicrm_dsn_close();
 }
 
 /**
- * Implementation of drush_hook_COMMAND_validate for command 'civicrm-sql-query'
+ * Implementation of drush_hook_pre_COMMAND for command 'civicrm-sql-query'
  */
-function drush_civicrm_sqlquery_validate() {
+function drush_civicrm_pre_civicrm_sql_query() {
   _civicrm_dsn_init();
 }
 
@@ -1159,7 +1165,10 @@ function drush_civicrm_sqlquery_validate() {
  * Implementation of command 'civicrm-sql-query'
  */
 function drush_civicrm_sqlquery($query) {
-  drush_sql_query($query);
+  return drush_sql_query($query);
+}
+
+function drush_civicrm_post_civicrm_sql_query() {
   _civicrm_dsn_close();
 }
 


### PR DESCRIPTION
There is still a lot of cleanup necessary for drush support to be completely working.  I'm not sure where things stopped working, but I tested with both drush 5 and 6 and neither seemed to work for me.
