### PR TITLE
group_roles_module - Avoid e-notice by early return

### DIFF
--- a/modules/civicrm_group_roles/civicrm_group_roles.module
+++ b/modules/civicrm_group_roles/civicrm_group_roles.module
@@ -629,6 +629,7 @@ function civicrm_group_roles_add_remove_groups($roles, $user, $op) {
       $variables = array( '@mail' => $user->mail );
       watchdog( 'civicrm',  $msg, $variables );
       if ( $debug_mode ) drupal_set_message( t( 'CiviCRM contact not found for %mail', array( '%mail' => $user->mail ) ) );
+      return;
     }
 
     $contact_id = CRM_Utils_Array::value( 'contact_id', $contact['values'][0] );


### PR DESCRIPTION
If there is no contact id then there is nothing further to do. However, the line which allocates a contact id gives an e-notice in this instance.  Add early return if no contact_id
