### PR TITLE
views-upgrade-error : due to column absence query fails in BAO's while 'enitity' drupal module tries to access core data of civicrm through views

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -65,8 +65,7 @@
  * Run hook_views_data for active CiviCRM components
  */
 function civicrm_views_data_alter(&$data) {
-
-  if (!civicrm_initialize()) {
+  if (!civicrm_initialize() || CRM_Utils_System::isInUpgradeMode()) {
     return;
   }
 


### PR DESCRIPTION
this PR is based (dependent) on : https://github.com/civicrm/civicrm-core/pull/3257
