### PR TITLE
CRM-15072 - use contact reference for staff responsible group

### DIFF
--- a/modules/civicrm_engage/CustomGroupData.xml
+++ b/modules/civicrm_engage/CustomGroupData.xml
@@ -250,8 +250,10 @@
     </CustomField>
     <CustomField>
       <label>Staff Responsible</label>
-      <data_type>String</data_type>
-      <html_type>Select</html_type>
+      <name>staff_responsible</name>
+      <data_type>ContactReference</data_type>
+      <html_type>Autocomplete-Select</html_type>
+      <filter>action=lookup&amp;group=2</filter>
       <is_required>0</is_required>
       <is_searchable>1</is_searchable>
       <is_search_range>0</is_search_range>
@@ -263,7 +265,6 @@
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
       <column_name>staff_responsible</column_name>
-      <option_group_name>staff_responsible_values</option_group_name>
       <custom_group_name>Constituent_Info_Individuals</custom_group_name>
     </CustomField>
     <CustomField>
@@ -730,8 +731,10 @@
     </CustomField>
     <CustomField>
       <label>Event Contact Person</label>
-      <data_type>String</data_type>
-      <html_type>Select</html_type>
+      <name>event_contact_person</name>
+      <data_type>ContactReference</data_type>
+      <html_type>Autocomplete-Select</html_type>
+      <filter>action=lookup&amp;group=2</filter>
       <is_required>0</is_required>
       <is_searchable>1</is_searchable>
       <is_search_range>0</is_search_range>
@@ -743,7 +746,6 @@
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
       <column_name>event_contact_person</column_name>
-      <option_group_name>staff_responsible_values</option_group_name>
       <custom_group_name>Event_Details</custom_group_name>
     </CustomField>
     <CustomField>
@@ -1067,11 +1069,6 @@
     <OptionGroup>
       <name>constituent_type_ind_values</name>
       <title>Constituent Type Values</title>
-      <is_active>1</is_active>
-    </OptionGroup>
-    <OptionGroup>
-      <name>staff_responsible_values</name>
-      <title>Staff Responsible Values</title>
       <is_active>1</is_active>
     </OptionGroup>
     <OptionGroup>
@@ -1415,16 +1412,6 @@
         <is_reserved>0</is_reserved>
         <is_active>1</is_active>
     <option_group_name>constituent_type_ind_values</option_group_name>
-    </OptionValue>
-    <OptionValue>
-      <label>Add Staff Name Here</label>
-      <value>add_staff_name_here</value>
-      <is_default>0</is_default>
-      <weight>2</weight>
-      <is_optgroup>0</is_optgroup>
-      <is_reserved>0</is_reserved>
-      <is_active>1</is_active>
-      <option_group_name>staff_responsible_values</option_group_name>
     </OptionValue>
     <OptionValue>
       <label>Meeting</label>

--- a/modules/civicrm_engage/civicrm_engage.admin.inc
+++ b/modules/civicrm_engage/civicrm_engage.admin.inc
@@ -245,8 +245,66 @@ function civicrm_engage_load_custom_data() {
   $xml_file = civicrm_engage_get_absolute_module_path() . '/CustomGroupData.xml';
   require_once 'CRM/Utils/Migrate/Import.php';
   $import = new CRM_Utils_Migrate_Import();
-
   $import->run($xml_file);
+
+  // The xml file sets up a field with a contact reference limited to the staff
+  // group (staff responsible). So, we have to make sure the staff group exists
+  // and if not create it and update the id number in the staff responsible
+  // field definition.
+  drupal_set_message("Creating staff group.");
+  return civicrm_engage_load_staff_group();
+}
+
+/**
+ * Create group that will be used to populate the responsible
+ * staff custom data field.
+ **/
+function civicrm_engage_load_staff_group() {
+  // Record the id of the group we create so we can ensure that the
+  // staff responsible contact reference field is restricted to the 
+  // right group.
+  $id = NULL;
+  try {
+    // Check if it exists already
+    $params = array('name' => 'staff');
+    $result = civicrm_api3('Group', 'Get', $params);
+    if($result['count'] > 0) {
+      // We already have the group in place.
+      drupal_set_message(t("Staff group already exists."));
+      $row = array_pop($result['values']);
+      $id = $row['id'];
+    }
+    else {
+      // Otherwise, we have to add it.
+      $params = array(
+        'name' => 'staff',
+        'title' => 'Staff',
+        'description' => 'Contacts in this group are used to populate the staff responsible field.',
+        'is_active' => 1,
+        'group_type' => '2',
+        'is_hidden' => '0',
+        'is_reserved' => '0'
+      );
+      $result = civicrm_api3('Group', 'create', $params);
+      drupal_set_message(t("Staff group created."));
+      $row = array_pop($result['values']);
+      $id = $row['id'];
+    }
+    if($id) {
+      $sql = "UPDATE civicrm_custom_field SET filter = 'action=lookup&group=%0' WHERE
+        name = 'staff_responsible' OR name = 'event_contact_person'";
+      $params = array(
+        0 => array($id, 'Integer')
+      );
+      CRM_Core_DAO::executeQuery($sql, $params);
+    }
+  }
+  catch (CiviCRM_API3_Exception $e) {
+    drupal_set_message(t("Failed to load staff group."));
+    drupal_set_message($e->getMessage());
+    return FALSE;
+  }
+  return TRUE;
 }
 
 function civicrm_engage_load_custom_voter_us_data() {


### PR DESCRIPTION
---
- CRM-15072: staff responsible and event contact fields should be contact reference fields not option groups
  https://issues.civicrm.org/jira/browse/CRM-15072
