### PR TITLE
CRM-15315 - in civicrm_group_roles_show_rules, fetch all groups, not jus...

### DIFF
--- a/modules/civicrm_group_roles/civicrm_group_roles.module
+++ b/modules/civicrm_group_roles/civicrm_group_roles.module
@@ -332,6 +332,7 @@ function civicrm_group_roles_show_rules($action = NULL, $id = NULL) {
   // get civicrm groups
   $params = array(
     'version' => '3',
+    'option.limit' => 0,
   );
 
   $groups = civicrm_api('group_contact','get',$params);


### PR DESCRIPTION
...t first 25 (D6 version).

---
- CRM-15315: CiviGroup Roles Sync rules listing has blank groups
  https://issues.civicrm.org/jira/browse/CRM-15315
