### PR TITLE
Metatag fix (tweak)

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -1207,6 +1207,7 @@ function civicrm_modules_uninstalled($modules) {
  */
 function civicrm_metatag_page_cache_cid_parts_alter(&$cid_parts) {
   if (!empty($cid_parts['path']) && substr($cid_parts['path'], 0, 7) == 'civicrm') {
-    $cid_parts['path'] .=  '/' . md5(print_r(ksort($_GET), true));
+    ksort($_GET);
+    $cid_parts['path'] .=  '/' . md5(print_r($_GET, true));
   }
 }


### PR DESCRIPTION
I had to do the ksort separately on its own line or it was just hashing the number 1 for all paths (and returning the same hash, defeating the purpose).
