### PR TITLE
CRM-15140

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -1259,7 +1259,10 @@ function civicrm_modules_uninstalled($modules) {
  * @param array $cid_parts
  */
 function civicrm_metatag_page_cache_cid_parts_alter(&$cid_parts) {
-  if (!empty($cid_parts['path']) && substr($cid_parts['path'], 0, 7) == 'civicrm') {
-    $cid_parts['path'] .=  '/' . md5(print_r(ksort($_GET), true));
+  if (isset($cid_parts['path']) && substr($cid_parts['path'], 0, 7) == 'civicrm') {
+    $get = $_GET;
+    ksort($get);
+    $cid_parts['path'] .= '/' . md5(print_r($get, true));
   }
 }
+

--- a/civicrm.module
+++ b/civicrm.module
@@ -1259,7 +1259,7 @@ function civicrm_modules_uninstalled($modules) {
  * @param array $cid_parts
  */
 function civicrm_metatag_page_cache_cid_parts_alter(&$cid_parts) {
-  if (isset($cid_parts['path']) && substr($cid_parts['path'], 0, 7) == 'civicrm') {
+  if (!empty($cid_parts['path']) && substr($cid_parts['path'], 0, 7) == 'civicrm') {
     $get = $_GET;
     ksort($get);
     $cid_parts['path'] .= '/' . md5(print_r($get, true));


### PR DESCRIPTION
Recognise that ksort() returns a boolean rather than an array; prevent PHP generating a notice by replacing !empty() with isset(); and prevent a potential side-effect by not sorting $_GET (lest some code depends on its current order)
