### PR TITLE
CRM-15539 fix for No Support for CiviVolunteer in Views

### DIFF
--- a/modules/views/components/civicrm.event.inc
+++ b/modules/views/components/civicrm.event.inc
@@ -659,27 +659,27 @@ function _civicrm_event_data(&$data, $enabled) {
   $sql = "SHOW TABLES LIKE 'civicrm_volunteer_project'";
   $result = CRM_Core_DAO::executeQuery($sql);
   if($result->fetch()){
-	  $data['civicrm_volunteer_project']['table']['group'] = t('CiviCRM CiviVolunteer');
-	  $data['civicrm_volunteer_project']['table']['join'] = array(
-	  	'civicrm_event' => array(
-	  		'left_field' => 'id',
-	  		'field' => 'entity_id',
-	  	),
-	  );
-	  //Add check to see if volunteering is turned on
-	  $data['civicrm_volunteer_project']['is_active'] = array(
-	    'title' => t('Is Volunteering On'),
-	    'help' => t('Is Volunteering enabled for the event?'),
-	    'field' => array(
-	      'handler' => 'views_handler_field_boolean',
-	      'click sortable' => FALSE,
-	    ),
-	    'filter' => array(
-	      'handler' => 'views_handler_filter_boolean_operator',
-	    ),
-	    'sort' => array(
-	      'handler' => 'views_handler_sort',
-	    ),
-         );
+		$data['civicrm_volunteer_project']['table']['group'] = t('CiviCRM CiviVolunteer');
+		  $data['civicrm_volunteer_project']['table']['join'] = array(
+		  	'civicrm_event' => array(
+		  		'left_field' => 'id',
+		  		'field' => 'entity_id',
+		  	),
+		  );
+		  //Add check to see if volunteering is turned on
+		  $data['civicrm_volunteer_project']['is_active'] = array(
+		    'title' => t('Is Volunteering On'),
+		    'help' => t('Is Volunteering enabled for the event?'),
+		    'field' => array(
+		      'handler' => 'views_handler_field_boolean',
+		      'click sortable' => FALSE,
+		    ),
+		    'filter' => array(
+		      'handler' => 'views_handler_filter_boolean_operator',
+		    ),
+		    'sort' => array(
+		      'handler' => 'views_handler_sort',
+		    ),
+      );
+    }
   }
-}

--- a/modules/views/components/civicrm.event.inc
+++ b/modules/views/components/civicrm.event.inc
@@ -655,31 +655,32 @@ function _civicrm_event_data(&$data, $enabled) {
       'handler' => 'civicrm_handler_field_link_participant',
     ),
   );
+
   //Add CiviVolunteer if it is installed
   $sql = "SHOW TABLES LIKE 'civicrm_volunteer_project'";
   $result = CRM_Core_DAO::executeQuery($sql);
-  if($result->fetch()){
-		$data['civicrm_volunteer_project']['table']['group'] = t('CiviCRM CiviVolunteer');
-		  $data['civicrm_volunteer_project']['table']['join'] = array(
-		  	'civicrm_event' => array(
-		  		'left_field' => 'id',
-		  		'field' => 'entity_id',
-		  	),
-		  );
-		  //Add check to see if volunteering is turned on
-		  $data['civicrm_volunteer_project']['is_active'] = array(
-		    'title' => t('Is Volunteering On'),
-		    'help' => t('Is Volunteering enabled for the event?'),
-		    'field' => array(
-		      'handler' => 'views_handler_field_boolean',
-		      'click sortable' => FALSE,
-		    ),
-		    'filter' => array(
-		      'handler' => 'views_handler_filter_boolean_operator',
-		    ),
-		    'sort' => array(
-		      'handler' => 'views_handler_sort',
-		    ),
-      );
-    }
+  if ($result->fetch()) {
+    $data['civicrm_volunteer_project']['table']['group'] = t('CiviCRM CiviVolunteer');
+    $data['civicrm_volunteer_project']['table']['join'] = array(
+      'civicrm_event' => array(
+        'left_field' => 'id',
+        'field' => 'entity_id',
+      ),
+    );
+    //Add check to see if volunteering is turned on
+    $data['civicrm_volunteer_project']['is_active'] = array(
+      'title' => t('Is Volunteering On'),
+      'help' => t('Is Volunteering enabled for the event?'),
+      'field' => array(
+        'handler' => 'views_handler_field_boolean',
+        'click sortable' => FALSE,
+      ),
+      'filter' => array(
+        'handler' => 'views_handler_filter_boolean_operator',
+      ),
+      'sort' => array(
+        'handler' => 'views_handler_sort',
+      ),
+    );
   }
+}

--- a/modules/views/components/civicrm.event.inc
+++ b/modules/views/components/civicrm.event.inc
@@ -655,4 +655,31 @@ function _civicrm_event_data(&$data, $enabled) {
       'handler' => 'civicrm_handler_field_link_participant',
     ),
   );
+  //Add CiviVolunteer if it is installed
+  $sql = "SHOW TABLES LIKE 'civicrm_volunteer_project'";
+  $result = CRM_Core_DAO::executeQuery($sql);
+  if($result->fetch()){
+	  $data['civicrm_volunteer_project']['table']['group'] = t('CiviCRM CiviVolunteer');
+	  $data['civicrm_volunteer_project']['table']['join'] = array(
+	  	'civicrm_event' => array(
+	  		'left_field' => 'id',
+	  		'field' => 'entity_id',
+	  	),
+	  );
+	  //Add check to see if volunteering is turned on
+	  $data['civicrm_volunteer_project']['is_active'] = array(
+	    'title' => t('Is Volunteering On'),
+	    'help' => t('Is Volunteering enabled for the event?'),
+	    'field' => array(
+	      'handler' => 'views_handler_field_boolean',
+	      'click sortable' => FALSE,
+	    ),
+	    'filter' => array(
+	      'handler' => 'views_handler_filter_boolean_operator',
+	    ),
+	    'sort' => array(
+	      'handler' => 'views_handler_sort',
+	    ),
+         );
+  }
 }


### PR DESCRIPTION
Checks to see if CiviVolunteer is installed, if it is it adds the ability to check if volunteering has been enabled on that event.
