### PR TITLE
CRM-16023. Remove lesser required versions of PHP.

### DIFF
--- a/modules/civicrm_contact_ref/civicrm_contact_ref.info
+++ b/modules/civicrm_contact_ref/civicrm_contact_ref.info
@@ -4,7 +4,6 @@ description = Makes a CiviCRM Contact Reference Field
 package = CiviCRM
 core = 7.x
 version = 4.6
-php = 5.2
 
 dependencies[] = civicrm
 dependencies[] = text

--- a/modules/civicrm_engage/civicrm_engage.info
+++ b/modules/civicrm_engage/civicrm_engage.info
@@ -4,6 +4,5 @@ version = 4.6
 dependencies[] = civicrm
 package = CiviCRM
 core = 7.x
-php = 5.2
 
 files[] = civicrm_engage.module

--- a/modules/civicrm_og_sync/civicrm_og_sync.info
+++ b/modules/civicrm_og_sync/civicrm_og_sync.info
@@ -5,6 +5,5 @@ dependencies[] = civicrm
 dependencies[] = og
 package = CiviCRM
 core = 7.x
-php = 5.2
 
 files[] = civicrm_og_sync.module


### PR DESCRIPTION
Since these modules depend on CiviCRM and CiviCRM requires PHP v5.3, we do not need to specify that these modules require PHP v5.2.
