### PR TITLE
CRM-16122. Expose custom field values in human-friendly format.

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_custom.inc
+++ b/modules/views/civicrm/civicrm_handler_field_custom.inc
@@ -61,6 +61,8 @@ class civicrm_handler_field_custom extends views_handler_field {
     $value = $values->{$this->field_alias};
     switch ($this->options['civicrm_custom_formatter']) {
       case 'value':
+        $value = trim($value, CRM_Core_DAO::VALUE_SEPARATOR);
+        $value = implode(', ', explode(CRM_Core_DAO::VALUE_SEPARATOR, $value));
         return $value;
 
       case 'label':


### PR DESCRIPTION
Having to do implode(explode)) feels a bit hackish ... should CiviCRM be providing some formatting on values retrieved by this point?
