### PR TITLE
turn off Drupal Form API cache specifically for quickform-based forms…

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -891,7 +891,7 @@ function civicrm_add_jquery(&$html) {
   return $html;
 }
 
-function civicrm_form_alter(&$form, $formValues, $formID) {
+function civicrm_form_alter(&$form, &$formValues, $formID) {
   switch ($formID) {
     case 'user_admin_permissions':
       $form['#submit'][] = 'civicrm_user_admin_permissions_submit';
@@ -913,6 +913,7 @@ function civicrm_form_alter(&$form, $formValues, $formID) {
         NULL, TRUE, FALSE
       );
       $form = array_merge($form, $output);
+      $formValues['no_cache'] = TRUE;
       break;
 
     case 'user_profile_form':
@@ -942,6 +943,7 @@ function civicrm_form_alter(&$form, $formValues, $formID) {
           $form = array_merge($form, $output);
         }
       }
+      $formValues['no_cache'] = TRUE;
       break;
 
     default:


### PR DESCRIPTION
… embedded to Drupal forms
