### PR TITLE
prevent conflicts on templates_c CRM-16604

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -1454,7 +1454,8 @@ function _civicrm_init($fail = TRUE) {
   }
   // include settings file
   define('CIVICRM_SETTINGS_PATH', $civicrmSettingsFile);
-  if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {//override the templates_c to avoid conflict
+  //override the templates_c to avoid conflict. It also means system.flush is going to clear drush cache, not the "real" one
+  if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {
     define('CIVICRM_TEMPLATE_COMPILEDIR',drush_tempdir());
   }
   include_once $civicrmSettingsFile;

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -64,6 +64,7 @@
  *   An associative array describing your command(s).
  */
 function civicrm_drush_command() {
+
   $items = array();
 
   // the key in the $items array is the name of the command.
@@ -1453,6 +1454,9 @@ function _civicrm_init($fail = TRUE) {
   }
   // include settings file
   define('CIVICRM_SETTINGS_PATH', $civicrmSettingsFile);
+  if (!defined('CIVICRM_TEMPLATE_COMPILEDIR')) {//override the templates_c to avoid conflict
+    define('CIVICRM_TEMPLATE_COMPILEDIR',drush_tempdir());
+  }
   include_once $civicrmSettingsFile;
   global $civicrm_root;
   if (!is_dir($civicrm_root)) {


### PR DESCRIPTION
http://civicrm.stackexchange.com/questions/2923/civicrm-does-not-have-permission-to-write-temp-files/2937#2937

Prevent "CiviCRM does not have permission to write temp files in ... templates_c/..." error messages.
"Drush command terminated abnormally due to an unrecoverable error"

Two users are trying to access the temp files (where, for instance, the compiled templates are stored): www-data (when it's accessed from the website) and the sysadmin that run drush commands

By default, all these temporary files can only modified by the user that created it, so sometimes it's the sysadmin, sometimes it's the webserver user

---
- [CRM-16604: drush and www-data conficts on templates_c permission](https://issues.civicrm.org/jira/browse/CRM-16604)
