### PR TITLE
CRM-16710 : Support for line-items in views integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# civicrm-drupal
+CiviCRM (Drupal Integration) - adding line-items support
+
+# CRM-16710 
+Support for line-items in views integration

--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-# civicrm-drupal
-CiviCRM (Drupal Integration) - adding line-items support
-
-# CRM-16710 
-Support for line-items in views integration

--- a/civicrm.info
+++ b/civicrm.info
@@ -90,6 +90,7 @@ files[] = modules/views/civicrm/views_handler_argument_civicrm_year_month.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_relationship.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_contact2users.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_memberships_contributions.inc
 
 ; views plugins
 files[] = modules/views/plugins/calendar_plugin_row_civicrm.inc

--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -97,6 +97,8 @@ function civicrm_views_data_alter(&$data) {
   ) {
     include_once 'components/civicrm.contribute.inc';
     _civicrm_contribute_data($data, $enabled);
+    include_once 'components/civicrm.lineitem.inc';
+    _civicrm_lineitem_data($data, $enabled);
   }
   if (isset($enabled['CiviEvent'])) {
     include_once 'components/civicrm.event.inc';

--- a/modules/views/civicrm/civicrm_handler_relationship_memberships_contributions.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_memberships_contributions.inc
@@ -1,0 +1,85 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * Field handler to provide relationship between memberships and contributions
+ *
+ * @ingroup civicrm_field_handlers
+ */
+class civicrm_handler_relationship_memberships_contributions extends views_handler_relationship {
+
+  /**
+   * Called to implement a relationship in a query.
+   */
+  function query() {
+    $join = new views_join();
+    if($this->options['table'] == "civicrm_membership"){
+      $join->definition = array(
+        'left_table' => 'civicrm_membership',
+        'left_field' => 'id',
+        'table' => 'civicrm_membership_payment',
+        'field' => 'membership_id',
+      );
+    }else{
+      $join->definition = array(
+        'left_table' => 'civicrm_contribution',
+        'left_field' => 'id',
+        'table' => 'civicrm_membership_payment',
+        'field' => 'contribution_id',
+      );
+
+    }
+
+    if (!empty($this->options['required'])) {
+      $join->definition['type'] = 'INNER';
+    }
+
+    // Continue our JOIN
+    $join->construct();
+
+    $this->first_join = $this->query->add_table('civicrm_membership_payment', $this->relationship, $join);
+
+
+    // Then, create a relationship on that table:
+    $join = new views_join();
+    $join->definition = array(
+      'left_table' => $this->first_join,
+      'left_field' => $this->options['field'],
+      'table' => $this->definition['base'],
+      'field' => $this->definition['base field'],
+    );
+
+    if (!empty($this->options['required'])) {
+      $join->definition['type'] = 'INNER';
+    }
+
+    $join->construct();
+
+    $alias = $join->definition['table'] . '_' . $join->definition['left_table'];
+
+    $this->alias = $this->query->add_relationship($alias, $join, $this->definition['base'], $this->relationship);
+  }
+}
+

--- a/modules/views/components/civicrm.contribute.inc
+++ b/modules/views/components/civicrm.contribute.inc
@@ -547,12 +547,35 @@ function _civicrm_contribute_data(&$data, $enabled) {
       ),
     );
   }
-
-
+  // Link to Membership table
+  if (isset($enabled['CiviMember'])) {
+    $data['civicrm_contribution']['membership_id'] = array(
+      'title' => t('Memberships Records'),
+      'help' => 'Bring memberships records',
+      'relationship' => array(
+        'base' => 'civicrm_membership',
+        'base field' => 'id',
+        'handler' => 'civicrm_handler_relationship_memberships_contributions',
+        'label' => t('Contribution -> Membership'),
+      ),
+    );
+  }
+  //link to line-items
+  $data['civicrm_contribution']['line_item_id'] = array(
+    'title' => t('Line-items Records'),
+    'help' => 'Bring line-items records',
+    'relationship' => array(
+      'base' => 'civicrm_line_item',
+      'base field' => 'contribution_id',
+      'field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('Contribution -> line-item'),
+    ),
+  );
+  
   /*
-     * Soft Credits
-     */
-
+   * Soft Credits
+   */
 
   $data['civicrm_contribution_soft']['table']['group'] = t('CiviCRM  Soft Credits');
 

--- a/modules/views/components/civicrm.lineitem.inc
+++ b/modules/views/components/civicrm.lineitem.inc
@@ -1,0 +1,225 @@
+<?php
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.6                                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+*/
+
+/**
+ * Build the $data array for CiviLineItem related tables
+ * Includes the following tables
+ * civicrm_line_item
+ */
+function _civicrm_lineitem_data(&$data, $enabled) {
+  //------------------------------------------------------
+  // CIVICRM Line Items are here with all the connections.
+  //------------------------------------------------------
+
+  $data['civicrm_line_item']['table']['group'] = t('CiviCRM Line-items');
+
+  $data['civicrm_line_item']['table']['base'] = array(
+    // Governs the whole mozilla
+    'field' => 'id',
+    'title' => t('CiviCRM Line-items'),
+    'help' => t("View displays CiviCRM Line-items."),
+  );
+  
+  
+  //CiviCRM Line-items - FIELDS
+
+  // Link to contribution table
+  if (isset($enabled['CiviContribute'])) {
+    $data['civicrm_line_item']['contribution_id'] = array(
+      'title' => t('Contributions Records'),
+      'help' => 'Bring contributions records',
+      'relationship' => array(
+        'base' => 'civicrm_contribution',
+        'base field' => 'id',
+        'handler' => 'views_handler_relationship',
+        'label' => t('line-item -> Contribution'),
+      ),
+    );
+  }
+  
+  // Line-item ID field
+  $data['civicrm_line_item']['id'] = array(
+      'title' => t('ID'),
+      'help' => t('The numeric Line-item\'s ID.'),
+      'field' => array(
+          'handler' => 'views_handler_field_numeric',
+      ),
+      'argument' => array(
+          'handler' => 'views_handler_argument_numeric',
+      ),
+      'filter' => array(
+          'handler' => 'views_handler_filter_numeric',
+          'allow empty' => TRUE,
+      ),
+      'sort' => array(
+          'handler' => 'views_handler_sort',
+      ),
+  );
+  
+  // Line-item label
+  $data['civicrm_line_item']['label'] = array(
+      'title' => t('Label'),
+      'help' => t('The line item label, display the formatted amount'),
+      'field' => array(
+          'handler' => 'views_handler_field',
+          'click sortable' => TRUE,
+      ),
+      'argument' => array(
+          'handler' => 'views_handler_argument_string',
+      ),
+      'filter' => array(
+          'handler' => 'views_handler_filter_string',
+          'allow empty' => TRUE,
+      ),
+      'sort' => array(
+          'handler' => 'views_handler_sort',
+      ),
+  );
+
+  // Line-item - price field relationship
+  $data['civicrm_line_item']['price_field_id'] = array(
+    'title' => t('Price Field'),
+    'help' => t('Price Field for this line item'),
+    'real field' => 'price_field_id',
+    'relationship' => array(
+      'base' => 'civicrm_price_field',
+      'base field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('Price Field'),
+    ),
+  );
+  
+  // Line-item - price field value relationship
+  $data['civicrm_line_item']['price_field_value_id'] = array(
+    'title' => t('Price Field Value'),
+    'help' => t('Price Field Value for this line item'),
+    'real field' => 'price_field_value_id',
+    'relationship' => array(
+      'base' => 'civicrm_price_field_value',
+      'base field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('Price Field Value'),
+    ),
+  );
+  
+  // Line-item - contribution relationship
+  $data['civicrm_line_item']['entity_id'] = array(
+      'title' => t('Contribution Record ID'),
+      'help' => t('Bring Contribution Record the complete contribution record to the party'),
+      'relationship' => array(
+          'base' => 'civicrm_contribution',
+          'left_field' => 'id',
+          'field' => 'entity_id',
+          'handler' => 'views_handler_relationship',
+          'label' => t('CiviCRM Contribution, with custom fields'),
+      ),
+  );
+    
+  // Line-Item Total amount
+  $data['civicrm_line_item']['line_total'] = array(
+      'title' => t('Total Line Item'),
+      'help' => t('The Total for the line item'),
+      'field' => array(
+          'handler' => 'views_handler_field_numeric',
+          'click sortable' => TRUE,
+      ),
+      'argument' => array(
+          'handler' => 'views_handler_argument_numeric',
+          'numeric' => TRUE,
+      ),
+      'filter' => array(
+          'handler' => 'views_handler_filter_numeric',
+      ),
+      'sort' => array(
+          'handler' => 'views_handler_sort',
+      ),
+  );
+
+  // Line-Item unit price
+  $data['civicrm_line_item']['unit_price'] = array(
+      'title' => t('Unit Price Item'),
+      'help' => t('The unit price for this line-item'),
+      'field' => array(
+          'handler' => 'civicrm_handler_field_money',
+          'click sortable' => TRUE,
+      ),
+      'argument' => array(
+          'handler' => 'views_handler_argument_numeric',
+          'numeric' => TRUE,
+      ),
+      'filter' => array(
+          'handler' => 'views_handler_filter_numeric',
+      ),
+      'sort' => array(
+          'handler' => 'views_handler_sort',
+      ),
+  );
+  
+  // Line-Item quantity
+  $data['civicrm_line_item']['qty'] = array(
+      'title' => t('Item quantity'),
+      'help' => t('The quantity for this line-item'),
+      'field' => array(
+          'handler' => 'views_handler_field_numeric',
+          'click sortable' => TRUE,
+      ),
+      'argument' => array(
+          'handler' => 'views_handler_argument_numeric',
+          'numeric' => TRUE,
+      ),
+      'filter' => array(
+          'handler' => 'views_handler_filter_numeric',
+      ),
+      'sort' => array(
+          'handler' => 'views_handler_sort',
+      ),
+  );
+  
+  // Line-item financial type
+  $data['civicrm_line_item']['financial_type'] = array(
+      'title' => t('Line item Financial Type'),
+      'real field' => 'financial_type_id',
+      'field' => array(
+          'handler' => 'civicrm_handler_field_pseudo_constant',
+          'click sortable' => TRUE,
+          'pseudo class' => 'CRM_Contribute_PseudoConstant',
+          'pseudo method' => 'financialType',
+      ),
+      'argument' => array(
+          'handler' => 'views_handler_argument',
+      ),
+      'filter' => array(
+          'handler' => 'civicrm_handler_filter_pseudo_constant',
+          'allow empty' => TRUE,
+          'pseudo class' => 'CRM_Contribute_PseudoConstant',
+          'pseudo method' => 'financialType',
+      ),
+      'sort' => array(
+          'handler' => 'views_handler_sort',
+      ),
+  );
+
+}
+

--- a/modules/views/components/civicrm.member.inc
+++ b/modules/views/components/civicrm.member.inc
@@ -107,6 +107,26 @@ function _civicrm_member_data(&$data, $enabled) {
     ),
   );
 
+  //Membership Type ID
+  $data['civicrm_membership']['membership_type_id'] = array(
+    'title' => t('Membership Type ID'),
+    'help' => t('The numeric ID of the Membership Type'),
+    'field' => array(
+      'handler' => 'views_handler_field_numeric',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+  
   //Membership Join date
   $data['civicrm_membership']['join_date'] = array(
     'title' => t('Join Date'),
@@ -328,6 +348,19 @@ function _civicrm_member_data(&$data, $enabled) {
         'base field' => 'id',
         'handler' => 'views_handler_relationship',
         'label' => t('Membership -> Campaign'),
+      ),
+    );
+  }
+  // Link to Contribution table
+  if (isset($enabled['CiviContribute'])) {
+    $data['civicrm_membership']['contribution_id'] = array(
+      'title' => t('Contribution Records'),
+      'help' => 'Bring contributions records',
+      'relationship' => array(
+        'base' => 'civicrm_contribution',
+        'base field' => 'id',
+        'handler' => 'civicrm_handler_relationship_memberships_contributions',
+        'label' => t('Membership -> Contribution'),
       ),
     );
   }

--- a/modules/views/components/civicrm.price_set.inc
+++ b/modules/views/components/civicrm.price_set.inc
@@ -610,6 +610,19 @@ function _civicrm_price_set_data(&$data, $enabled) {
     ),
   );
 
+  // Price set
+  $data['civicrm_price_field']['price_set'] = array(
+    'title' => t('Price Set'),
+    'help' => t('Price Set related to this Price Field'),
+    'real field' => 'price_set_id',
+    'relationship' => array(
+      'base' => 'civicrm_price_set',
+      'base field' => 'id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('Price Set'),
+    ),
+  );
+  
   //----------------------------------------------------------------
   // CIVICRM Price Field Value - BASE TABLE
   //----------------------------------------------------------------


### PR DESCRIPTION
New features for Drupal views integration.
- adding possibility to join contributions to line-items
- adding possibility to join line-items to price and prive-value fields
- adding possibility to join contributions and memberships (two-way) if civiMember and civiContribute are both activated.

(feature previously discussed on CRM-15398)
