### PR TITLE
Bug with module "commons_trusted_contacts"

### DIFF
--- a/modules/civicrm_og_sync/civicrm_og_sync.module
+++ b/modules/civicrm_og_sync/civicrm_og_sync.module
@@ -295,7 +295,7 @@ function _civicrm_og_sync_node_action($node) {
   }
 
 function _civicrm_og_sync_group_action($membership, $op = 'add') {
-  if ($membership->entity_type != 'user' || !civicrm_initialize() || _civicrm_og_sync_skip_process_request()) {
+  if ($membership->entity_type != 'user' || !civicrm_initialize() || _civicrm_og_sync_skip_process_request() || $membership->type == "trusted_contacts") {
     return;
   }
 


### PR DESCRIPTION
Go inside function "civicrm og_sync_group_action" when you try to add two contacts like trusted contacts (with no civicrm group relation).
