### PR TITLE
CRM-6877: Inform Drupal that fields should have no TZ handling.

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -86,3 +86,12 @@ function civicrm_update_7400(&$sandbox) {
   db_query("UPDATE {system} SET weight = 100 WHERE name = 'civicrm'");
 }
 
+/**
+ * Trigger cache clear to pick up TZ handling change from CRM-6877.
+ */
+function civicrm_update_7401($sandbox) {
+  // This is an empty hook_update_N() so that caches will be
+  // cleared when update_finished() is called.
+  return t('TZ changes in CiviCRM Views picked up.');
+}
+

--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -709,7 +709,7 @@ function civicrm_date_views_fields($field) {
     // The type of date: DATE_UNIX, DATE_ISO, DATE_DATETIME.
     'sql_type' => DATE_DATETIME,
     // Timezone handling options: 'none', 'site', 'date', 'utc'.
-    'tz_handling' => 'site',
+    'tz_handling' => 'none',
     // Needed only for dates that use 'date' tz_handling.
     'timezone_field' => '',
     // Needed only for dates that use 'date' tz_handling.

--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -756,16 +756,16 @@ function civicrm_date_views_tables() {
  */
 function civicrm_views_plugins() {
   $data = array();
-  
+
   // This just tells us that the themes are elsewhere
   $data['module'] = 'civicrm';
-  
+
   // Default argument to pull CiviCRM IDs from the URL
   $data['argument default']['civicrm_id'] = array(
     'title' => t('CiviCRM ID from URL'),
     'handler' => 'civicrm_plugin_argument_default_civicrm_id'
   );
-  
+
   // Calendar module integration
   if (module_exists('calendar')) {
     $civicrm_module_path = drupal_get_path('module', 'civicrm');
@@ -833,7 +833,6 @@ function civicrm_views_plugins() {
       ),
     );
   }
-	
+
   return $data;
 }
-


### PR DESCRIPTION
This change appears to resolve TZ issues when displaying CiviCRM Event / Activity dates in Drupal Calendar.

---
- [CRM-6877: Drupal Views Calendar Doesn't Correctly Handle Timezone](https://issues.civicrm.org/jira/browse/CRM-6877)
