### PR TITLE
CRM-17179 - CiviCRM Contact Ref - Contact Subtype handling fix

### DIFF
--- a/modules/civicrm_contact_ref/civicrm_contact_ref.module
+++ b/modules/civicrm_contact_ref/civicrm_contact_ref.module
@@ -351,8 +351,9 @@ function _civicrm_contact_ref_potential_references_standard($field, $string = ''
   }
 
   if (!empty($contactSubTypes)) {
-    $contactSubTypes = implode("','", $contactSubTypes);
-    $whereClause[] = "contact_sub_type IN ( '{$contactSubTypes}' )";
+    foreach ($contactSubTypes as $subType) {
+      $whereClause[] = "contact_sub_type LIKE '%" . CRM_Core_DAO::VALUE_SEPARATOR . $subType . CRM_Core_DAO::VALUE_SEPARATOR . "%'";
+    }
   }
 
   $whereClause = empty($whereClause) ? '' : '(' . implode(' OR ', $whereClause) . ') AND';


### PR DESCRIPTION
civicrm_contact table uses CRM_Core_DAO::VALUE_SEPARATOR for
storing multiple subtypes for one contact. civicrm_contact_ref
ignored this and simply used SQL IN() to test for matching. This
resulted in that a contact had multiple subtypes, it never matched.
So that's why I use separate WHERE clause to be able to do LIKE
operator and surround the value with the separator to avoid problems
with such types where one type is the substring of the another.

---
- [CRM-17179: CiviCRM Contact Ref contact subtype handling](https://issues.civicrm.org/jira/browse/CRM-17179)
