### PR TITLE
CRM-17468 - Drupal Views integration - add support for "is_primary" in address/phone/mail for sort and filter

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -76,6 +76,7 @@ files[] = modules/views/civicrm/civicrm_handler_field_activity.inc
 ; sort handlers
 files[] = modules/views/civicrm/civicrm_handler_sort_date.inc
 files[] = modules/views/civicrm/civicrm_handler_sort_pcp_raised_amount.inc
+files[] = modules/views/civicrm/civicrm_handler_sort_address_pseudoconstant.inc
 
 ; argument handlers
 files[] = modules/views/civicrm/civicrm_plugin_argument_default.inc
@@ -91,6 +92,10 @@ files[] = modules/views/civicrm/civicrm_handler_relationship.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_relationship.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_contact2users.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_memberships_contributions.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_location.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_mail.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_phone.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_address.inc
 
 ; views plugins
 files[] = modules/views/plugins/calendar_plugin_row_civicrm.inc

--- a/modules/views/civicrm/civicrm_handler_relationship_address.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_address.inc
@@ -1,0 +1,73 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * Field handler to provide relationship to CiviCRM email.
+ *
+ * @ingroup civicrm_relationship_handlers
+ */
+class civicrm_handler_relationship_address extends civicrm_handler_relationship_location {
+  
+  function ensure_my_table() {
+    if (!isset($this->table_alias)) {
+      if (!method_exists($this->query, 'ensure_table')) {
+        vpr_trace();
+        exit;
+      }
+      $extra = $this->location_extras();
+      if (isset($this->options['is_billing']) && $this->options['is_billing']) {
+        $extra[] = array(
+            'value' => $this->options['is_billing'],
+            'numeric' => TRUE,
+            'field' => 'is_billing',
+            'operator' => '=',
+        );
+      }
+      if (isset($extra) && !empty($extra)) {
+        $join = $this->get_join();
+        $join->extra = $extra;
+        // Decide between And/Or
+        $join->extra_type = self::$_locationOps[$this->options['location_op']];
+        $this->table_alias = $this->query->add_table($this->table, $this->relationship, $join);
+      } else {
+        $this->table_alias = $this->query->ensure_table($this->table, $this->relationship);
+      }
+    }
+    return $this->table_alias;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    $form['is_billing'] = array(
+        '#type' => 'checkbox',
+        '#title' => 'Use only Billing Address record?',
+        '#options' => array(0 => 'No', 1 => 'Yes'),
+        '#description' => t('Check above box if you want only the <strong>Billing Address</strong> record used in this relationship.'),
+        '#default_value' => $this->options['is_billing'],
+        '#fieldset' => 'location_choices',
+    );
+  }
+}
+

--- a/modules/views/civicrm/civicrm_handler_relationship_location.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_location.inc
@@ -1,0 +1,139 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * Field handler to provide relationship to CiviCRM email.
+ *
+ * @ingroup civicrm_relationship_handlers
+ */
+class civicrm_handler_relationship_location extends views_handler_relationship {
+
+  static $_locationTypes;
+  static $_locationOps;
+  static $location_op;
+
+  function construct() {
+    parent::construct();
+    if (!self::$_locationTypes) {
+      if (!civicrm_initialize()) {
+        return;
+      }
+      require_once 'CRM/Core/PseudoConstant.php';
+      self::$_locationTypes = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
+      self::$_locationOps = array(0 => 'AND', 1 => 'OR');
+    }
+  }
+
+  function option_definition() {
+    $options = parent::option_definition();
+    $options['location_type'] = array('default' => 0);
+    $options['location_op'] = array('default' => 0);
+    $options['is_primary'] = array('default' => '');
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $locationOptions = array(0 => 'Any');
+    foreach (self::$_locationTypes as $id => $type) {
+      $locationOptions[$id] = $type;
+    }
+    $label = $this->definition['title'];
+    $form['label'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Label'),
+      '#default_value' => $label,
+      '#dependency' => array(
+        'edit-options-custom-label' => array(1),
+      ),
+      '#weight' => -102,
+    );
+    $form['location_choices'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('CiviCRM Location Relationship Options'),
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+      '#description' => '<strong>Note:</strong> it is possible to choose relationship options that result in no rows being displayed',
+      '#weight' => 1,
+    );
+    $form['location_op'] = array(
+      '#type' => 'select',
+      '#title' => 'And/Or',
+      '#options' => self::$_locationOps,
+      '#description' => t('Relationship option are joined by And/Or?'),
+      '#default_value' => $this->options['location_op'],
+      '#fieldset' => 'location_choices',
+    );
+    $form['location_type'] = array(
+      '#type' => 'radios',
+      '#title' => 'Location type for this relationship',
+      '#options' => $locationOptions,
+      '#description' => t('Location type to be used for this relationship'),
+      '#default_value' => $this->options['location_type'],
+      '#fieldset' => 'location_choices',
+    );
+    $form['is_primary'] = array(
+      '#type' => 'checkbox',
+      '#title' => 'Use only Primary record?',
+      '#options' => array(0 => 'No', 1 => 'Yes'),
+      '#description' => t('Check above box if you want only the <strong>Primary</strong> record used in this relationship.'),
+      '#default_value' => $this->options['is_primary'],
+      '#fieldset' => 'location_choices',
+    );
+  }
+
+
+  function location_extras() {
+    $extra = array();
+    if (!empty($this->options['location_type'])) {
+      $extra[] = array(
+        'value' => $this->options['location_type'],
+        'numeric' => TRUE,
+        'field' => 'location_type_id',
+        'operator' => '=',
+      );
+    }
+    if (!empty($this->options['is_primary'])) {
+      $extra[] = array(
+        'value' => $this->options['is_primary'],
+        'numeric' => TRUE,
+        'field' => 'is_primary',
+        'operator' => '=',
+      );
+    }
+    return $extra;
+  }
+
+  /**
+   * Called to implement a relationship in a query.
+   */
+  function query() {
+    // Just ensure the one table. This is briefer than parent::query(), which
+    // attempts to create an additional join.
+    $this->ensure_my_table();
+  }
+}
+

--- a/modules/views/civicrm/civicrm_handler_relationship_mail.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_mail.inc
@@ -1,0 +1,63 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * Field handler to provide relationship to CiviCRM email.
+ *
+ * @ingroup civicrm_relationship_handlers
+ */
+class civicrm_handler_relationship_mail extends civicrm_handler_relationship_location {
+  
+  function ensure_my_table() {
+    if (!isset($this->table_alias)) {
+      if (!method_exists($this->query, 'ensure_table')) {
+        vpr_trace();
+        exit;
+      }
+      $extra = $this->location_extras();
+      if (isset($extra) && !empty($extra)) {
+        $join        = $this->get_join();
+        $join->extra = $extra;
+        // Decide between And/Or
+        $join->extra_type = self::$_locationOps[$this->options['location_op']];
+        $this->table_alias = $this->query->add_table($this->table, $this->relationship, $join);
+      }
+      else {
+        $this->table_alias = $this->query->ensure_table($this->table, $this->relationship);
+      }
+    }
+    return $this->table_alias;
+  }
+
+  /**
+   * Called to implement a relationship in a query.
+   */
+  function query() {
+    // Just ensure the one table. This is briefer than parent::query(), which
+    // attempts to create an additional join.
+    $this->ensure_my_table();
+  }
+}
+

--- a/modules/views/civicrm/civicrm_handler_relationship_phone.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_phone.inc
@@ -1,0 +1,104 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * Field handler to provide relationship to CiviCRM email.
+ *
+ * @ingroup civicrm_relationship_handlers
+ */
+class civicrm_handler_relationship_phone extends civicrm_handler_relationship_location {
+  
+  static $_phoneType;
+  function construct() {
+    parent::construct();
+    if (!self::$_phoneType) {
+      if (!civicrm_initialize()) {
+        return;
+      }
+      self::$_phoneType = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Phone', 'phone_type_id');
+    }
+  }
+
+  function option_definition() {
+    $options = parent::option_definition();
+    $options['phone_type'] = array('default' => 0);
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    $phoneOptions = array(0 => 'Any');
+    foreach (self::$_phoneType as $id => $type) {
+      $phoneOptions[$id] = $type;
+    }
+    $form['phone_type'] = array(
+      '#type' => 'radios',
+      '#title' => 'Phone type for this relationship',
+      '#options' => $phoneOptions,
+      '#description' => t('Phone type to be used for this relationship'),
+      '#default_value' => $this->options['phone_type'],
+      '#fieldset' => 'location_choices',
+    );
+  }
+
+  function ensure_my_table() {
+    if (!isset($this->table_alias)) {
+      if (!method_exists($this->query, 'ensure_table')) {
+        vpr_trace();
+        exit;
+      }
+      if (isset($this->options['phone_type']) && $this->options['phone_type']) {
+        $join    = $this->get_join();
+        $extra   = parent::location_extras();
+        $extra[] = array(
+          'value' => $this->options['phone_type'],
+          'numeric' => TRUE,
+          'field' => 'phone_type_id',
+          'operator' => '=',
+        );
+        $join->extra       = $extra;
+        $join->extra_type  = self::$_locationOps[$this->options['location_op']];
+        $this->table_alias = $this->query->add_table($this->table, $this->relationship, $join);
+      }
+      else {
+        $join              = $this->get_join();
+        $join->extra       = parent::location_extras();
+        $join->extra_type  = self::$_locationOps[$this->options['location_op']];
+        $this->table_alias = $this->query->add_table($this->table, $this->relationship, $join);
+      }
+    }
+    return $this->table_alias;
+  }
+
+  /**
+   * Called to implement a relationship in a query.
+   */
+  function query() {
+    // Just ensure the one table. This is briefer than parent::query(), which
+    // attempts to create an additional join.
+    $this->ensure_my_table();
+  }
+}
+

--- a/modules/views/civicrm/civicrm_handler_sort_address_pseudoconstant.inc
+++ b/modules/views/civicrm/civicrm_handler_sort_address_pseudoconstant.inc
@@ -1,0 +1,76 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * sort handler to properly pass the field type for date fields.
+ *
+ */
+class civicrm_handler_sort_address_pseudoconstant extends views_handler_sort {
+  /**
+   * The table alias of the additional joined table.
+   *
+   * @var _join_alias
+   */
+  private   $_join_alias;
+
+  function ensure_my_table() {
+    $join_table = $this->definition['join_table'];
+    $join_field = $this->definition['join_field'];
+    $join_left_field = $this->definition['join_left_field'];
+    
+    $alias = parent::ensure_my_table();
+
+    // Use the relationship if one is specified; otherwise, use the base table_alias.
+    $relationship_id = (array_key_exists('relationship', $this->options) ? $this->options['relationship'] : '');
+    if ($relationship_id && $relationship_id != 'none') {
+      $table_alias = $this->view->relationship[$relationship_id]->table_alias;
+    }
+    else {
+      $table_alias = $this->table_alias;
+    }
+
+    // If the table_alias is still unknown, use the base table
+    if (!$table_alias) {
+      $table_alias = $this->table;
+    }
+
+    // Create a new join object and provide it with information about the join
+    $join = new views_join();
+    $join->construct($join_table, $table_alias, $join_left_field, $join_field, NULL, 'LEFT');
+
+    // Define an alias and use add_reliationship to add the join to the query.
+    $this->_join_alias = $join_table . '_' . $this->table;
+    $join_table_alias = $this->query->add_relationship($this->_join_alias, $join, $table_alias, $this->relationship);
+
+    return $table_alias;
+  }
+
+  function query() {
+    $this->ensure_my_table();
+    $this->query->add_orderby($this->_join_alias, 'name', $this->options['order']);
+  }
+
+}
+

--- a/modules/views/civicrm/civicrm_handler_sort_county.inc
+++ b/modules/views/civicrm/civicrm_handler_sort_county.inc
@@ -1,0 +1,39 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * sort handler to properly pass the field type for date fields.
+ *
+ */
+class civicrm_handler_sort_county extends civicrm_handler_sort_address_pseudoconstant {
+
+  function ensure_my_table() {
+    $this->_join_table = 'civicrm_county';
+    $this->_join_left_field = 'county_id';
+    $this->_join_field = 'id';
+
+    return parent::ensure_my_table();
+  }
+}

--- a/modules/views/civicrm/civicrm_handler_sort_state.inc
+++ b/modules/views/civicrm/civicrm_handler_sort_state.inc
@@ -1,0 +1,40 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ * sort handler to properly pass the field type for date fields.
+ *
+ */
+class civicrm_handler_sort_state extends civicrm_handler_sort_address_pseudoconstant {
+
+  function ensure_my_table() {
+    $this->_join_table = 'civicrm_state_province';
+    $this->_join_left_field = 'state_province_id';
+    $this->_join_field = 'id';
+
+    return parent::ensure_my_table();
+  }
+}
+

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -758,6 +758,19 @@ function _civicrm_core_data(&$data, $enabled) {
     'field' => 'contact_id',
   );
 
+  // ADDRESS ID
+  $data['civicrm_address']['id'] = array(
+    'title' => t('Address'),
+    'help' => t('Contact Address'),
+    'relationship' => array(
+      'base' => 'civicrm_contact',
+      'field' => 'id',
+      'relationship table' => 'civicrm_address',
+      'relationship field' => 'contact_id',
+      'handler' => 'civicrm_handler_relationship_address',
+      'label' => t('CiviCRM Address'),
+    ),
+  );
 
   //BOOLEAN : IS PRIMARY ADDRESS
   $data['civicrm_address']['is_primary'] = array(
@@ -926,7 +939,10 @@ function _civicrm_core_data(&$data, $enabled) {
       'pseudo method' => 'stateProvince',
     ),
     'sort' => array(
-      'handler' => 'views_handler_sort',
+      'join_table' => 'civicrm_state_province',
+      'join_left_field' => 'state_province_id',
+      'join_field' => 'id',
+      'handler' => 'civicrm_handler_sort_address_pseudoconstant',
     ),
   );
 
@@ -1014,7 +1030,10 @@ function _civicrm_core_data(&$data, $enabled) {
       'pseudo method' => 'country',
     ),
     'sort' => array(
-      'handler' => 'views_handler_sort',
+      'join_table' => 'civicrm_country',
+      'join_left_field' => 'country_id',
+      'join_field' => 'id',
+      'handler' => 'civicrm_handler_sort_address_pseudoconstant',
     ),
   );
 
@@ -1039,7 +1058,10 @@ function _civicrm_core_data(&$data, $enabled) {
       'pseudo method' => 'county',
     ),
     'sort' => array(
-      'handler' => 'views_handler_sort',
+      'join_table' => 'civicrm_county',
+      'join_left_field' => 'county_id',
+      'join_field' => 'id',
+      'handler' => 'civicrm_handler_sort_address_pseudoconstant',
     ),
   );
 
@@ -1162,6 +1184,20 @@ function _civicrm_core_data(&$data, $enabled) {
     'left_field' => 'contact_id',
     'field' => 'contact_id',
   );
+  
+  // EMAIL ADDRESS ID
+  $data['civicrm_email']['id'] = array(
+    'title' => t('Email Address'),
+    'help' => t('Contact Email Address'),
+    'relationship' => array(
+      'base' => 'civicrm_contact',
+      'field' => 'id',
+      'relationship table' => 'civicrm_email',
+      'relationship field' => 'contact_id',
+      'handler' => 'civicrm_handler_relationship_mail',
+      'label' => t('CiviCRM Email'),
+    ),
+  );
 
   //BOOLEAN : IS PRIMARY EMAIL
   $data['civicrm_email']['is_primary'] = array(
@@ -1179,6 +1215,7 @@ function _civicrm_core_data(&$data, $enabled) {
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
+      'handler' => 'civicrm_handler_sort_mail',
     ),
   );
 
@@ -1389,6 +1426,20 @@ function _civicrm_core_data(&$data, $enabled) {
     ),
     'sort' => array(
       'handler' => 'views_handler_sort',
+    ),
+  );
+
+  // PHONE ID
+  $data['civicrm_phone']['id'] = array(
+    'title' => t('Phone'),
+    'help' => t('Contact Phone Number'),
+    'relationship' => array(
+      'base' => 'civicrm_contact',
+      'field' => 'id',
+      'relationship table' => 'civicrm_phone',
+      'relationship field' => 'contact_id',
+      'handler' => 'civicrm_handler_relationship_phone',
+      'label' => t('CiviCRM Phone'),
     ),
   );
 


### PR DESCRIPTION
This also includes a fix for CRM-15994, fixing sort for country/state/county so that
they sort by name, not ID. This fix creates Views Relationships for Address, Phone,
and Email, in which the user can stipulate is_primary and other properties of an
address/phone/email. If these stipulations aren't relevant, the user can configure the
sort or filter without a relationship.  This relationship-based approach allows the user
to make those selections once in the relationship, rather than repeating the same
selections for each sort/filter (e.g., setting is_primary for each of country, state,
county, and city when sorting on all those fields)

---
- [CRM-17468: Address-related filter and sort criteria in Views lack support for "use primary address" setting](https://issues.civicrm.org/jira/browse/CRM-17468)
- [CRM-15994: Sort by Country, State, or County in Views sorts by ID, not by name](https://issues.civicrm.org/jira/browse/CRM-15994)
