### PR TITLE
CRM-17594 civicrm_metatag_metatags_view_alter()

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -271,6 +271,9 @@ function _civicrm_get_url_parameters_as_url_string() {
  *  Context.
  */
 function civicrm_metatag_metatags_view_alter(&$output, $instance) {
+  if (arg(0) != 'civicrm') {
+    return;
+  }
   $linkUrls = array('og:url', 'canonical', 'shortlink');
   foreach ($linkUrls as $url) {
     if (isset($output[$url]['#attached']['drupal_add_html_head'][0][0]['#value'])) {


### PR DESCRIPTION
civicrm_metatag_metatags_view_alter() should only act on CiviCRM pages

---
- [CRM-17594: civicrm_metatag_metatags_view_alter() should only act on CiviCRM pages](https://issues.civicrm.org/jira/browse/CRM-17594)
