### PR TITLE
8.x master

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -5,21 +5,21 @@ define('CIVICRM_UF_HEAD', TRUE);
 require_once 'civicrm.user.inc';
 
 /**
- * Implements hook_page_top().
+ * Implements hook_page_attachments().
  *
- * The aim of this is to inject arbitrary html into the head region.
- * This hook is used only as a convenient time in the page-load cycle
- * to inject this html: we use the deprecated _drupal_add_html_head() for actually
- * getting the markup on the page.
+ * Inject arbitrary html into the head region.
  */
-function civicrm_page_top(&$page_top) {
+function civicrm_page_attachments(array &$page) {
+  
   $headers = \Drupal::service('civicrm.page_state')->getHtmlHeaders();
+  $markup  = [
+    '#type'   => 'markup',
+    '#weight' => -99,
+    '#markup' => \Drupal\Component\Utility\SafeMarkup::format($headers, []),
+  ];
+  
+  $page['#attached']['html_head'][] = [$markup, 'civicrm-headers'];
 
-   _drupal_add_html_head(array(
-     '#type' => 'markup',
-     '#weight' => -99,
-     '#markup' => \Drupal\Component\Utility\SafeMarkup::set($headers, 'all'),
-   ), 'civicrm-headers');
 }
 
 /**

--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -68,7 +68,7 @@ class CivicrmController extends ControllerBase {
     // been taken care of. The SafeMarkup::set() function is stated to be used for
     // internal use only, so this is a cludge.
     $build = array(
-      '#markup' => SafeMarkup::set($content, 'all'),
+      '#markup' => SafeMarkup::format($content, []),
     );
     $counter = 0;
     foreach ($this->civicrmPageState->getCSS() as $css) {
@@ -86,7 +86,7 @@ class CivicrmController extends ControllerBase {
       // Mark the pageTitle as safe so markup is not escaped by Drupal.
       // This handles the case where, eg. the page title is surrounded by <span id="crm-remove-title" style=display: none">
       // Todo: This is a naughty way to do this. Better to have CiviCRM passing us no markup whatsoever.
-      \Drupal\Component\Utility\SafeMarkup::set($title);
+      \Drupal\Component\Utility\SafeMarkup::format($title, []);
       $build['#title'] = $title;
     }
 


### PR DESCRIPTION
Changed some calls to _drupal_add_html_head() and \Drupal\Component\Utility\SafeMarkup::set(), as they've been removed from the latest 8.x release.
