### PR TITLE
CRM-17609: Corrected retrieval of current user uid.

### DIFF
--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -56,7 +56,7 @@ class CivicrmController extends ControllerBase {
     }
 
     // Synchronize the Drupal user with the Contacts database (why?)
-    $this->civicrm->synchronizeUser($this->currentUser());
+    $this->civicrm->synchronizeUser(\Drupal\user\Entity\User::load($this->currentUser()->id()));
 
     // Add CSS, JS, etc. that is required for this page.
     \CRM_Core_Resources::singleton()->addCoreResources();
@@ -92,4 +92,5 @@ class CivicrmController extends ControllerBase {
 
     return $build;
   }
+
 }


### PR DESCRIPTION
- [CRM-17609: D8 - Synchronize Users to Contacts broken](https://issues.civicrm.org/jira/browse/CRM-17609)
