### PR TITLE
CRM-17966: Removed reference to non-existent Drupal method.

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -206,7 +206,7 @@ function civicrm_form_user_register_form_alter(&$form, &$form_state, $form_id) {
   $html = \CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', 1, TRUE, FALSE, NULL, FALSE, $civicrm->getCtype());
 
   $form['civicrm_profile_register'] = array(
-    '#markup' => Drupal\Component\Utility\SafeMarkup::set($html, 'all'),
+    '#markup' => Drupal\Component\Utility\SafeMarkup::format($html, []),
   );
   $form['#validate'][] = '_civicrm_user_register_form_validate';
 }


### PR DESCRIPTION
- [CRM-17966: Fatal error in Drupal 8 user creation](https://issues.civicrm.org/jira/browse/CRM-17966)
