### PR TITLE
CRM-18222. Use Drupal functions for discovery of CiviCRM install location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Installation Steps
 
 - Download the latest Drupal 8 release: (from https://www.drupal.org/project/drupal).
 - Install Drupal 8 (see https://api.drupal.org/api/drupal/core!INSTALL.txt/8 for more information).
-- Create a top level `libraries` folder inside Drupal and download CiviCRM master (for Drupal 7) (from http://dist.civicrm.org/by-date/latest/master/) so that CiviCRM resides at `/libraries/civicrm`.
-- Remove the Drupal 7 module folder from within CiviCRM (`libraries/civicrm/drupal`).
+- Create a top level `libraries` folder inside Drupal and download CiviCRM master (for Drupal 7) (from http://dist.civicrm.org/by-date/latest/master/) so that CiviCRM resides at `/libraries/civicrm`. CiviCRM can also be installed in /modules/civicrm - see CRM-18222.
+- If it exists, remove the Drupal 7 module folder from within CiviCRM (`libraries/civicrm/drupal`).
 - Clone the Drupal 8 module into the the top level `modules` directory (this is where Drupal 8 contributed modules live now): `git clone -b 8.x-master https://github.com/civicrm/civicrm-drupal.git civicrm`
 - Edit civicrm-version.php and change the 'cms' value from 'Drupal' to 'Drupal8'. If you are reading this after having already installed CiviCRM and running into an undefined `arg(0)` error, change the CIVICRM_UF value in your civicrm.settings.php file.
 - If you want the installer to load dummy contacts and data, add the following configuration parameter to `sites/default/settings.php`: `$settings['civicrm_load_generated'] = TRUE;`

--- a/civicrm.install
+++ b/civicrm.install
@@ -115,12 +115,28 @@ function civicrm_requirements($phase) {
   return $requirements;
 }
 
+/**
+ * Returns the path to where CiviCRM is installed.
+ *
+ * @return string|void
+ *
+ * Recommended location for civicrm is in /libraries/civicrm [citation needed].
+ * We also allow /modules/civicrm, which seems to work fine.
+ */
 function _civicrm_find_civicrm() {
-  // Only acceptable location for civicrm is in /libraries/civicrm
-  $path =  \Drupal::root() . '/libraries/civicrm';
-  if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
-    return realpath($path);
+  if ($path = drupal_get_path('module', 'civicrm')) {
+    if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
+      return \Drupal\Core\File\FileSystem::realpath($path);
+    }
   }
+
+  if ($path = libraries_get_path('civicrm')) {
+    if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
+      return \Drupal\Core\File\FileSystem::realpath($path);
+    }
+  }
+
+  return NULL;
 }
 
 /**


### PR DESCRIPTION
Refs #361.

---
- [CRM-18222: Drupal 8 support: allow installation in \/modules](https://issues.civicrm.org/jira/browse/CRM-18222)
