### PR TITLE
CRM-18365 - Drupal Integration - Don't include filter module files

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -227,9 +227,6 @@ function civicrm_initialize() {
       foreach ($formats as $id => $format) {
         wysiwyg_get_profile($id);
       }
-      $path = drupal_get_path('module', 'filter');
-      drupal_add_js($path . '/filter.js');
-      drupal_add_css($path . '/filter.css');
     }
   }
   setMySQLTimeZone();


### PR DESCRIPTION
Don't include filter module files not present in Drupal 6.

(Also see https://forum.civicrm.org/index.php?topic=30365.0)

---
- CRM-18365:
  https://issues.civicrm.org/jira/browse/CRM-18365
