### PR TITLE
Fix invalid index errors on clearing cache in D8.

### DIFF
--- a/modules/civicrm_views/civicrm_views.views.inc
+++ b/modules/civicrm_views/civicrm_views.views.inc
@@ -676,7 +676,7 @@ function _civicrm_views_get_custom_fields() {
       'table' => $dao->table_name,
       'name' => "custom_{$dao->id}",
       'real field' => $dao->column_name,
-      'type' => _getStandardTypeFromCustomDataType($dao->data_type),
+      'type' => _getStandardTypeFromCustomDataType(array('data_type' => $dao->data_type)),
       'join' => _civicrm_views_get_join_table($dao->extends),
       'pseudoconstant' => $dao->option_group_id,
     );


### PR DESCRIPTION
_getStandardTypeFromCustomDataType expects array, but was handed a string. This fixes errors on clearing cache in Drupal 8.
