### PR TITLE
Don't look for Wordpress in a Drupal installation

### DIFF
--- a/civicrm.config.php.drupal
+++ b/civicrm.config.php.drupal
@@ -64,9 +64,6 @@ function civicrm_conf_init() {
         // check to see if this is under sites/all/modules
         } else if ( strpos( $currentDir, $moduleDir ) !== false ) {
             $confdir = $currentDir . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..';
-        } else if ( strpos( $currentDir, 'plugins' . DIRECTORY_SEPARATOR . 'civicrm' . DIRECTORY_SEPARATOR . 'civicrm' ) !== false ) {
-             //if its wordpress
-            $confdir = $currentDir . DIRECTORY_SEPARATOR . '..';
         } else {
             $confdir = $currentDir . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
         }


### PR DESCRIPTION
This file is a bit of a train wreck. This is just a small improvement for now.
