### PR TITLE
Fix for CRM-18451

### DIFF
--- a/modules/civicrmtheme/civicrmtheme.module
+++ b/modules/civicrmtheme/civicrmtheme.module
@@ -124,7 +124,8 @@ function civicrmtheme_custom_theme() {
 
   // Check for public pages
   // If public page and civicrm public theme is set, apply civicrm public theme
-  if (CRM_Utils_Array::value('is_public', $item)) {
+  // If user does not have access to CiviCRM use the public page for the error message
+  if (!user_access('access CiviCRM') || CRM_Utils_Array::value('is_public', $item)) {
     if ($public_theme) {
       return $public_theme;
     }


### PR DESCRIPTION
Only use admin theme if user has access to CiviCRM.

---
- [CRM-18451: Users without access to CiviCRM get admin theme on access denied](https://issues.civicrm.org/jira/browse/CRM-18451)
