### PR TITLE
Replace IN to MANY_TO_ONE

### DIFF
--- a/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
@@ -32,7 +32,7 @@
  * Filters Activity Statuses, and is configured using the labels from the database
  *
  */
-class civicrm_handler_filter_pseudo_constant extends views_handler_filter_in_operator {
+class civicrm_handler_filter_pseudo_constant extends views_handler_filter_many_to_one {
   public $_pseudo_constant; function construct() {
     parent::construct();
     if (!civicrm_initialize() ||


### PR DESCRIPTION
It seems that many_to_one provides more options at exposed filter operators level; namely it adds "Is all of" option which makes Tags search return only contacts  tagged by ALL tags; useful  for multiply tags search. Not sure about caveats, there must be some.
