### PR TITLE
CRM-17789 - Support PHP 7 - mysqli support in _civicrm_install_db

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -381,15 +381,15 @@ function _civicrm_install_db($dbuser, $dbpass, $dbhost, $dbname,
   $siteRoot = drush_get_context('DRUSH_DRUPAL_SITE_ROOT', FALSE);
 
   $sqlPath = "$modPath/civicrm/sql";
-  $conn = @mysql_connect($dbhost, $dbuser, $dbpass);
-  if (!@mysql_select_db($dbname) &&
-    !@mysql_query("CREATE DATABASE $database")
+  $conn = @mysqli_connect($dbhost, $dbuser, $dbpass);
+  if (!@mysqli_select_db($conn, $dbname) &&
+    !@mysqli_query($conn, "CREATE DATABASE $dbname")
   ) {
     drush_die(dt('CiviCRM database was not found. Failed to create one.'));
   }
 
   // setup database with civicrm structure and data
-  $dsn = "mysql://{$dbuser}:{$dbpass}@{$dbhost}/{$dbname}?new_link=true";
+  $dsn = "mysqli://{$dbuser}:{$dbpass}@{$dbhost}/{$dbname}?new_link=true";
   drush_log(dt("Loading CiviCRM database structure .."));
   civicrm_source($dsn, $sqlPath . '/civicrm.mysql');
   drush_log(dt("Loading CiviCRM database with required data .."));


### PR DESCRIPTION
- [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)
