### PR TITLE
Update civicrm.info.yml

### DIFF
--- a/civicrm.info.yml
+++ b/civicrm.info.yml
@@ -4,3 +4,5 @@ description: 'Constituent Relationship Management system. Allows sites to manage
 package: CiviCRM
 version: 8.x-4.7
 core: 8.x
+dependencies:
+  -  libraries:libraries

--- a/civicrm.install
+++ b/civicrm.install
@@ -126,17 +126,15 @@ function civicrm_requirements($phase) {
 function _civicrm_find_civicrm() {
   if ($path = drupal_get_path('module', 'civicrm')) {
     if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
-      return \Drupal\Core\File\FileSystem::realpath($path);
+      return \Drupal::service('file_system')->realpath($path);
     }
   }
 
   if ($path = libraries_get_path('civicrm')) {
     if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
-      return \Drupal\Core\File\FileSystem::realpath($path);
+      return \Drupal::service('file_system')->realpath($path);
     }
   }
-
-  return NULL;
 }
 
 /**


### PR DESCRIPTION
Resolve CRM-18297 by requiring the Libraries API to install
Resolve CRM-19086 by fixing real_path call.

---
- [CRM-18297: Drupal 8 Crash on Admin Config page](https://issues.civicrm.org/jira/browse/CRM-18297)

---
- [CRM-19086: CiviCRM Core Installation fails on Drupal 8.1.x](https://issues.civicrm.org/jira/browse/CRM-19086)
