### PR TITLE
Fix variable name in 'drush' update code

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -370,8 +370,8 @@ function drush_civicrm_install() {
 
 function _civicrm_extract_tarfile($destinationPath, $option = 'tarfile') {
   $tarpath = drush_get_option($option, FALSE);
-  if (drush_shell_exec("gzip -d " . $tarfile)) {
-    $tarpath = substr($tarfile, 0, strlen($tarfile) - 3);
+  if (drush_shell_exec("gzip -d " . $tarpath)) {
+    $tarpath = preg_replace('/(tar\.gz|tgz)$/', 'tar', $tarpath);
   }
   drush_shell_exec("tar -xf $tarpath -C \"$destinationPath\"");
 }


### PR DESCRIPTION
Looks like the variable `$tarpath` is mistakenly referred to as `$tarfile` in the `_civicrm_extract_tarfile` function a few places - if so, this function wouldn't have worked properly since early 2013 (which agrees with my experience).

In addition, since `.tgz` and `.tar.gz` are both common suffixes for gzipped tar files, the code now properly handles both variants.
