### PR TITLE
mysqli_connect() expects parameter 5 to be long in _civicrm_install_db

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -386,7 +386,7 @@ function _civicrm_install_db($dbuser, $dbpass, $dbhost, $dbname,
 
   if (function_exists('mysqli_connect')) {
     $dbhostParts = explode(':', $dbhost);
-    $conn = @mysqli_connect($dbhostParts[0], $dbuser, $dbpass, '', isset($dbhostParts[1]) ? $dbhostParts[1] : '');
+    $conn = @mysqli_connect($dbhostParts[0], $dbuser, $dbpass, '', isset($dbhostParts[1]) ? $dbhostParts[1] : null);
     $dbOK = ($a = @mysqli_select_db($conn, $dbname)) || ($b = @mysqli_query($conn, "CREATE DATABASE $dbname"));
   }
   elseif (function_exists('mysql_connect')) {


### PR DESCRIPTION
drush civicrm-install dies with the following error
"mysqli_connect() expects parameter 5 to be long, string given civicrm.drush.inc:389"
Replacing the empty string with solves the problem
