### PR TITLE
CRM-19387: Use translated labels instead of names

### DIFF
--- a/modules/views/civicrm/civicrm_handler_filter_relationship_type.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_relationship_type.inc
@@ -41,7 +41,7 @@ class civicrm_handler_filter_relationship_type extends views_handler_filter_in_o
         return;
       }
       require_once 'CRM/Core/PseudoConstant.php';
-      $relationshipType_array = CRM_Core_PseudoConstant::relationshipType($columnName = 'name');
+      $relationshipType_array = CRM_Core_PseudoConstant::relationshipType($columnName = 'label');
 
       // relationshipType() returns information about relations as array with fields
       // 'label_a_b', 'label_b_a', 'contact_type_a' and 'contact_type_b'.
@@ -49,7 +49,7 @@ class civicrm_handler_filter_relationship_type extends views_handler_filter_in_o
 
       $options = array();
       foreach ($relationshipType_array as $id => $value_array) {
-        $options[$id] = $value_array['name_a_b'];
+        $options[$id] = $value_array['label_a_b'];
       }
 
       self::$_relationshipType = $options;


### PR DESCRIPTION
When exposing relationship types to filters in Drupal views, we should use the labels because they're translated.

Somehow similar to CRM-16058

---
- [CRM-19387: Civi should expose relationship types's labels instead of names to Drupal views](https://issues.civicrm.org/jira/browse/CRM-19387)
- [CRM-16058: Drupal views retrieve participant status name instead of label](https://issues.civicrm.org/jira/browse/CRM-16058)
