### PR TITLE
CRM-19407: cannot install with mysqli if using default port.

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -386,7 +386,7 @@ function _civicrm_install_db($dbuser, $dbpass, $dbhost, $dbname,
 
   if (function_exists('mysqli_connect')) {
     $dbhostParts = explode(':', $dbhost);
-    $conn = @mysqli_connect($dbhostParts[0], $dbuser, $dbpass, '', isset($dbhostParts[1]) ? $dbhostParts[1] : '');
+    $conn = @mysqli_connect($dbhostParts[0], $dbuser, $dbpass, '', isset($dbhostParts[1]) ? $dbhostParts[1] : NULL);
     $dbOK = ($a = @mysqli_select_db($conn, $dbname)) || ($b = @mysqli_query($conn, "CREATE DATABASE $dbname"));
   }
   elseif (function_exists('mysql_connect')) {


### PR DESCRIPTION
- [CRM-19407: drush: cannot install with mysqli if using default port](https://issues.civicrm.org/jira/browse/CRM-19407)
