### PR TITLE
CRM-19545 Custom field groups missing from views

### DIFF
--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -2911,7 +2911,7 @@ function _civicrm_core_data(&$data, $enabled) {
 
   while ($dao->fetch()) {
     // call getTree using $dao->id as groupID, $dao->extends as entityType, with possible subtypes in $dao->extends_entity_column_value
-    $extendsContactSubtype = (('Contact' === $dao->extends) && !empty($dao->extends_entity_column_value));
+    $extendsContactSubtype = (in_array($dao->extends, array('Contact', 'Individual', 'Organization', 'Household')) && !empty($dao->extends_entity_column_value));
     $contactSubtypes = !$extendsContactSubtype ? NULL : array_filter(explode(CRM_Core_DAO::VALUE_SEPARATOR, $dao->extends_entity_column_value));
     $contactSubtypes = empty($contactSubtypes) ? NULL : $contactSubtypes;
     $data = civicrm_views_custom_data_cache($data, $dao->extends, $dao->id, $contactSubtypes);


### PR DESCRIPTION
Fix for CRM-19545 : "Custom field groups which do not directly extend the base 'Contact' disappear from Drupal view after applying patch CRM-18776"

---
- [CRM-19545: Custom field groups which do not directly extend the base 'Contact' disappear from Drupal view after applying patch CRM-18776](https://issues.civicrm.org/jira/browse/CRM-19545)
- [CRM-18776: Views and non-Contact entities with custom field groups](https://issues.civicrm.org/jira/browse/CRM-18776)
