### PR TITLE
CRM-19568 Expose processor ID to views

### DIFF
--- a/modules/views/components/civicrm.contribute.inc
+++ b/modules/views/components/civicrm.contribute.inc
@@ -943,6 +943,26 @@ function _civicrm_contribute_data(&$data, $enabled) {
     'title' => 'Recurring Contribution End Date',
       'name' => 'end_date',
     ));
+  //Prcocessor ID
+  $data['civicrm_contribution_recur']['processor_id'] = array(
+    'title' => t('Processor ID'),
+    'help' => t('The Processor ID of the Recurring Contribution'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+      'numeric' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
   //Unique Transaction ID
   $data['civicrm_contribution_recur']['trxn_id'] = array(
     'title' => t('Unique Transaction ID'),


### PR DESCRIPTION
- [CRM-19568: Expose recurring contribution processor ID to views](https://issues.civicrm.org/jira/browse/CRM-19568)
