### PR TITLE
CRM-19604: civicrm-ext-list: avoid default API limit of 25 results.

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -576,7 +576,7 @@ function civicrm_drush_help($section) {
 function drush_civicrm_ext_list() {
   civicrm_initialize();
   try{
-    $result = civicrm_api('extension', 'get', array('version' => 3));
+    $result = civicrm_api('extension', 'get', array('version' => 3, 'option.limit' => 0));
     $rows = array(array(dt('App name'), dt('Status')));
     foreach ($result['values'] as $k => $extension_data) {
       $rows[] = array(

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -576,7 +576,11 @@ function civicrm_drush_help($section) {
 function drush_civicrm_ext_list() {
   civicrm_initialize();
   try{
-    $result = civicrm_api('extension', 'get', array('version' => 3, 'option.limit' => 0));
+    $result = civicrm_api3('extension', 'get', array(
+      'options' => array(
+        'limit' => 0,
+      ),
+    ));
     $rows = array(array(dt('App name'), dt('Status')));
     foreach ($result['values'] as $k => $extension_data) {
       $rows[] = array(


### PR DESCRIPTION
* [CRM-19604: civicrm-ext-list: avoid default API limit of 25 results](https://issues.civicrm.org/jira/browse/CRM-19604)

---

 * [CRM-19404: Recommend PHP 5.3.23](https://issues.civicrm.org/jira/browse/CRM-19404)