### PR TITLE
CRM-19604: civicrm-ext-list: avoid default API limit of 25 results

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -549,7 +549,11 @@ function civicrm_drush_help($section) {
 function drush_civicrm_extension_list() {
   civicrm_initialize();
   try{
-    $result = civicrm_api('extension', 'get', array('version' => 3));
+    $result = civicrm_api3('extension', 'get', array(
+      'options' => array(
+        'limit' => 0,
+      ),
+    ));
     $rows = array(array(dt('App name'), dt('Status')));
     foreach ($result['values'] as $k => $extension_data) {
       $rows[] = array(


### PR DESCRIPTION
for the d6 branch..

I know this sounds pedantic, but I still manage some D6 sites, and shot myself in the foot because I was grepping around for sites using a specific extension, only to realize I was grepping incomplete results. :)

---

 * [CRM-19604: Drush: civicrm-ext-list only shows up to 25 extensions](https://issues.civicrm.org/jira/browse/CRM-19604)