### PR TITLE
CiviCRM Menu -- Add PathProcessor to allow parameters to routes to include slashes

### DIFF
--- a/civicrm.services.yml
+++ b/civicrm.services.yml
@@ -12,3 +12,4 @@ services:
     class: Drupal\civicrm\PathProcessor\CivicrmPathProcessor
     tags:
       - { name: path_processor_inbound, priority: 250 }
+      

--- a/civicrm.services.yml
+++ b/civicrm.services.yml
@@ -12,5 +12,3 @@ services:
     class: Drupal\civicrm\PathProcessor\CivicrmPathProcessor
     tags:
       - { name: path_processor_inbound, priority: 250 }
-
-      

--- a/civicrm.services.yml
+++ b/civicrm.services.yml
@@ -8,3 +8,7 @@ services:
     arguments: [@string_translation, @civicrm.page_state]
     tags:
       - { name: breadcrumb_builder, priority: 1002 }
+  civicrm.path_processor:
+    class: Drupal\civicrm\PathProcessor\CivicrmPathProcessor
+    tags:
+      - { name: path_processor_inbound, priority: 250 }

--- a/civicrm.services.yml
+++ b/civicrm.services.yml
@@ -12,5 +12,5 @@ services:
     class: Drupal\civicrm\PathProcessor\CivicrmPathProcessor
     tags:
       - { name: path_processor_inbound, priority: 250 }
-      
+
       

--- a/civicrm.services.yml
+++ b/civicrm.services.yml
@@ -13,3 +13,4 @@ services:
     tags:
       - { name: path_processor_inbound, priority: 250 }
       
+      

--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -31,7 +31,8 @@ class CivicrmController extends ControllerBase {
 
   public function main($args, $extra) {
     if ($extra) {
-      $args = array_merge($args, explode('/', $extra));
+     //kint($extra);
+      $args = array_merge($args, explode(':', $extra));
     }
 
     // CiviCRM's Invoke.php has hardwired in the expectation that the query parameter 'q' is being used.

--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -31,7 +31,6 @@ class CivicrmController extends ControllerBase {
 
   public function main($args, $extra) {
     if ($extra) {
-     //kint($extra);
       $args = array_merge($args, explode(':', $extra));
     }
 

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -12,7 +12,6 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
   public function processInbound($path, Request $request) {
     // if the path is a civicrm path   
     if (strpos($path, '/civicrm/') === 0) {
-      
       // initialize civicrm
       $civicrm = new Civicrm();
       // fetch civicrm menu items
@@ -40,8 +39,6 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
         else {
           return $longest;
         }
-       
-   
       }
     }
     return $path;

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -30,10 +30,13 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
       }
       if (!empty($longest)) {
         // parse url component parameters from path
-        $params = str_replace($longest . '/', '', $path);
+        $params = str_replace($longest, '', $path);
         // replace slashes with colons and the controller will piece it back together
         if(strlen($params)) {
           $params = str_replace('/', ':', $params);
+          if (substr($params, 0, 1) == ':') {
+           $params = substr($params, 1);
+          }
           return "$longest/$params";
         }
         else {

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -5,15 +5,29 @@ namespace Drupal\civicrm\PathProcessor;
 use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+use Drupal\civicrm\Civicrm;
+
 class CivicrmPathProcessor implements InboundPathProcessorInterface {
 
   public function processInbound($path, Request $request) {
-    if (strpos($path, '/civicrm/ajax/menujs') === 0) {
-      $params = preg_replace('|^\/civicrm\/ajax\/menujs\/|', '', $path);
-      $params = str_replace('/',':', $params);
-      return "/civicrm/ajax/menujs/$params";
+    // if the path is a civicrm path   
+    if (strpos($path, '/civicrm/') === 0) {
+      // initialize civicrm
+      $civicrm = new Civicrm();
+      // fetch civicrm menu items
+      $items = \CRM_Core_Menu::items();
+      foreach (array_keys($items) as $item) {
+        // if he current path is a civicrm path
+        if(('/' . $item  . '/') == $path) {
+          // discover any additional path components after the registered route
+          $regex_path = str_replace('/', '\/', $path);
+          $params = preg_replace("|^$regex_path|", '', $path);
+          // replace slashes with colons and the controller will piece it back together
+          $params = str_replace('/', ':', $params);
+          return "$path/$params";
+        }
+      }
     }
     return $path;
   }
-
 }

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\civicrm\PathProcessor;
+
+use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class CivicrmPathProcessor implements InboundPathProcessorInterface {
+
+  public function processInbound($path, Request $request) {
+    if (strpos($path, '/civicrm/ajax/menujs') === 0) {
+      $params = preg_replace('|^\/civicrm\/ajax\/menujs\/|', '', $path);
+      $params = str_replace('/',':', $params);
+      return "/civicrm/ajax/menujs/$params";
+    }
+    return $path;
+  }
+
+}

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -12,20 +12,34 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
   public function processInbound($path, Request $request) {
     // if the path is a civicrm path   
     if (strpos($path, '/civicrm/') === 0) {
+      
       // initialize civicrm
       $civicrm = new Civicrm();
       // fetch civicrm menu items
       $items = \CRM_Core_Menu::items();
+      $longest = '';
       foreach (array_keys($items) as $item) {
+        $item = '/' . $item;
         // if he current path is a civicrm path
-        if(('/' . $item  . '/') == $path) {
+        if ((strpos($path, $item ) === 0))  {
           // discover any additional path components after the registered route
-          $regex_path = str_replace('/', '\/', $path);
-          $params = preg_replace("|^$regex_path|", '', $path);
-          // replace slashes with colons and the controller will piece it back together
-          $params = str_replace('/', ':', $params);
-          return "$path/$params";
+          
+          if (strlen($item) > strlen($longest)) {
+           $longest = $item;
+          }
         }
+      }
+      if (!empty($longest)) {
+       
+        $regex_path = '|^' . str_replace('/', '\/', $longest) . '\/|';
+        $params = preg_replace($regex_path, '', $path);
+         
+          // replace slashes with colons and the controller will piece it back together
+        if(strlen($params)) {
+          $params = str_replace('/', ':', $params);
+        }
+        $new_path = "$longest/$params";
+        return $new_path;     
       }
     }
     return $path;

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -22,7 +22,7 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
         $item = '/' . $item;
         // if he current path is a civicrm path
         if ((strpos($path, $item ) === 0))  {
-          // discover any additional path components after the registered route
+          // discover longest matching civicrm path in the request path 
           
           if (strlen($item) > strlen($longest)) {
            $longest = $item;
@@ -30,16 +30,18 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
         }
       }
       if (!empty($longest)) {
-       
-        $regex_path = '|^' . str_replace('/', '\/', $longest) . '\/|';
-        $params = preg_replace($regex_path, '', $path);
+       $params = str_replace($longest, '', $path);
          
           // replace slashes with colons and the controller will piece it back together
         if(strlen($params)) {
           $params = str_replace('/', ':', $params);
+          return "$longest/$params";
         }
-        $new_path = "$longest/$params";
-        return $new_path;     
+        else {
+          return $longest;
+        }
+       
+   
       }
     }
     return $path;

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -29,9 +29,9 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
         }
       }
       if (!empty($longest)) {
-       $params = str_replace($longest, '', $path);
-         
-          // replace slashes with colons and the controller will piece it back together
+        // parse url component parameters from path
+        $params = str_replace($longest . '/', '', $path);
+        // replace slashes with colons and the controller will piece it back together
         if(strlen($params)) {
           $params = str_replace('/', ':', $params);
           return "$longest/$params";

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -37,6 +37,8 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
           if (substr($params, 0, 1) == ':') {
            $params = substr($params, 1);
           }
+          //\Drupal::logger('my_module')->notice('Path ' . $longest);
+          //\Drupal::logger('my_module')->notice('Params: ' . $params);
           return "$longest/$params";
         }
         else {

--- a/src/PathProcessor/CivicrmPathProcessor.php
+++ b/src/PathProcessor/CivicrmPathProcessor.php
@@ -37,8 +37,6 @@ class CivicrmPathProcessor implements InboundPathProcessorInterface {
           if (substr($params, 0, 1) == ':') {
            $params = substr($params, 1);
           }
-          //\Drupal::logger('my_module')->notice('Path ' . $longest);
-          //\Drupal::logger('my_module')->notice('Params: ' . $params);
           return "$longest/$params";
         }
         else {

--- a/src/Routing/Routes.php
+++ b/src/Routing/Routes.php
@@ -28,10 +28,9 @@ class Routes {
         ),
         array(
           '_access' => 'TRUE',
-          'extra' => '.*',
+          'extra' => '.+',
         )
       );
-
       $route_name = CivicrmHelper::parseURL($path)['route_name'];
       $collection->add($route_name, $route);
     }


### PR DESCRIPTION
So Drupal 8 doesn't allow route parameters with slashes without some trickery. 

You have to add a PathProcessor, and convert slashes to another character, in this case ':'

When we identify other paths that have parameters with slashes, we should add checks to the path processor and do a conversion....

