### PR TITLE
CRM-19835 Installing into D8, DB requirements fail using non-standard…

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -85,7 +85,6 @@ function civicrm_requirements($phase) {
 
   // Grab db connection info
   $db_config = _civicrm_get_db_config()['info'];
-  $db_config['host'] = "{$db_config['host']}:{$db_config['port']}";
 
   $install_requirements = new \Civi\Install\Requirements();
 


### PR DESCRIPTION
Reason for issue : This was mainly due to switching to mysqli_connect, without doing the corresponding parameter changes

Please take **https://github.com/civicrm/civicrm-core/pull/9755** along with this PR to make the fix complete.

Regards,
Vasantha Kaje