### PR TITLE
CRM 19835 Installing into D8, DB requirements fail using non-standard…

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -85,7 +85,6 @@ function civicrm_requirements($phase) {
 
   // Grab db connection info
   $db_config = _civicrm_get_db_config()['info'];
-  $db_config['host'] = "{$db_config['host']}:{$db_config['port']}";
 
   $install_requirements = new \Civi\Install\Requirements();
 


### PR DESCRIPTION
Removed the port number concatenation, as mysqli_connect api specs are different

[https://github.com/civicrm/civicrm-core/pull/9760](https://github.com/civicrm/civicrm-core/pull/9760) is the associated fix to civicrm-core