### PR TITLE
CRM-20298: Custom fields of type Money should use the same filter operators as Integer fields

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -594,6 +594,7 @@ function civicrm_views_get_filter($data_type, $html_type = NULL, $option_group_i
 
     case "Float":
     case "Int":
+    case "Money":
       return array('handler' => 'views_handler_filter_numeric', 'allow empty' => TRUE);
 
     case "Date":


### PR DESCRIPTION
* [CRM-20298: Drupal Views: Custom fields of type Money should use the same filter operators as Integer fields](https://issues.civicrm.org/jira/browse/CRM-20298)