### PR TITLE
CRM-20298: Custom fields of type Money should use the same filter operators as Integer fields

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -5305,6 +5305,7 @@ function civicrm_get_filter_handler($type) {
 
     case "Float":
     case "Int":
+    case "Money":
       return 'views_handler_filter_numeric';
 
     case "Date":


### PR DESCRIPTION
* [CRM-20298: Drupal Views: Custom fields of type Money should use the same filter operators as Integer fields](https://issues.civicrm.org/jira/browse/CRM-20298)