### PR TITLE
CRM-20203: Gmap Views broken (don't find geo_code)

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_address.inc
+++ b/modules/views/civicrm/civicrm_handler_field_address.inc
@@ -80,7 +80,8 @@ class civicrm_handler_field_address extends civicrm_handler_field_location {
         exit;
       }
       $join = $this->get_join();
-      if (empty($this->relationship)) { //https://www.drupal.org/node/2617032
+      //CRM-20203: Make sure latitude and longitude doesn't add more joins
+      if (empty($this->relationship) && strpos($this->field, 'geo_code_') != 0) { //https://www.drupal.org/node/2617032
         $this->table_alias = $this->query->add_table($this->table, $this->relationship, $join);
       } else {
         $this->table_alias = $this->query->ensure_table($this->table, $this->relationship, $join);


### PR DESCRIPTION
Not sure if it should be done in core, but it fixes CRM-20203. Due to changes in https://github.com/civicrm/civicrm-drupal/pull/415/files#diff-eb1aa2cc8ada7a16fe8b497a244d9cb7R83, a new join is added for each table field which breaks the alias(civicrm_address_geo_code_2) we select for IGVM Maps. With additional address join, alias is created as civicrm_address2_geo_code_2.

As this was in a working state before, did a PR to fix it in upper versions too.

---

 * [CRM-20203: Gmap Views broken \(don't find geo_code\)](https://issues.civicrm.org/jira/browse/CRM-20203)