### PR TITLE
CRM-20502 - Do not get custom group tree into cache if we are upgrading

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -304,6 +304,9 @@ function civicrm_views_add_date_arguments(&$data, $value) {
  *   Array with the new custom field appended
  */
 function civicrm_views_custom_data_cache(&$data, $entity_type, $group_id, $sub_type) {
+  if (!CRM_Core_Config::isUpgradeMode()) {
+    return;
+  }
   // From http://forum.civicrm.org/index.php/topic,17658.msg73901.html#msg73901, CRM-7860.
   $tree = CRM_Core_BAO_CustomGroup::getTree($entity_type, CRM_Core_DAO::$_nullObject, NULL, $group_id, $sub_type, NULL);
 

--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -304,7 +304,7 @@ function civicrm_views_add_date_arguments(&$data, $value) {
  *   Array with the new custom field appended
  */
 function civicrm_views_custom_data_cache(&$data, $entity_type, $group_id, $sub_type) {
-  if (!CRM_Core_Config::isUpgradeMode()) {
+  if (CRM_Core_Config::isUpgradeMode()) {
     return;
   }
   // From http://forum.civicrm.org/index.php/topic,17658.msg73901.html#msg73901, CRM-7860.


### PR DESCRIPTION
@eileenmcnaughton @totten @karing try this

---

 * [CRM-20502: Drush upgrade crashes on loading "is_public" field](https://issues.civicrm.org/jira/browse/CRM-20502)