### PR TITLE
CRM-20592 - remove location options from website field

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_website.inc
+++ b/modules/views/civicrm/civicrm_handler_field_website.inc
@@ -28,7 +28,7 @@
  *
  * @ingroup civicrm_field_handlers
  */
-class civicrm_handler_field_website extends civicrm_handler_field_location {
+class civicrm_handler_field_website extends civicrm_handler_field {
   static $_websiteType;
 
   public function construct() {


### PR DESCRIPTION
Simple fix to remove location options in Drupal views.
See https://issues.civicrm.org/jira/browse/CRM-20592 for more details.