### PR TITLE
CRM-20541 - Use drupal_static() instead of static

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -156,8 +156,8 @@ function civicrm_initialize() {
   }
   _civicrm_registerClassLoader();
 
-  static $initialized = FALSE;
-  static $failure = FALSE;
+  $initialized = &drupal_static('civicrm_initialize', FALSE);
+  $failure = &drupal_static('civicrm_initialize_failure', FALSE);
 
   if ($failure) {
     return FALSE;
@@ -687,7 +687,7 @@ function civicrm_user_form_validate($form, &$form_state) {
   // lets suppress key generation for all validation also
   civicrm_key_disable();
 
-  static $validated = FALSE;
+  $validated = &drupal_static(__FUNCTION__, FALSE);
 
   if ($validated) {
     return;


### PR DESCRIPTION
The impetus behind CRM-20541 seems to be a testing scenario where the
setup/teardown process resets Civi (`Civi::reset()`) without resetting
Drupal (`drupal_static_reset()`).  IMHO, it's better to keep the systems
aligned by either (a) resetting both or (b) resetting neither.

For the situation where you reset both, the state within
`civicrm_initialize()` needs some way to reset.  This function executes
within a Drupal context (before Civi has booted), so it should obey the
reset conventions for Drupal -- i.e.  use `drupal_static()`.

Ping @eileenmcnaughton

---

 * [CRM-20541: Edge case where DB connection is not available](https://issues.civicrm.org/jira/browse/CRM-20541)