### PR TITLE
CRM-19976: Fix for Drush: cannot disable civicrm debug

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -155,6 +155,9 @@ function civicrm_drush_command() {
   $items['civicrm-enable-debug'] = array(
     'description' => "Enable CiviCRM Debugging.",
   );
+  $items['civicrm-disable-debug'] = array(
+    'description' => "Disable CiviCRM Debugging.",
+  );
   $items['civicrm-upgrade'] = array(
     'description' => "Replace CiviCRM codebase with new specified tarfile and upgrade database by executing the CiviCRM upgrade process - civicrm/upgrade?reset=1.",
     'examples' =>


### PR DESCRIPTION
* [CRM-19976: Drush: cannot disable civicrm debug](https://issues.civicrm.org/jira/browse/CRM-19976)