### PR TITLE
CRM-20783 : Get currency from civi if not included in view fields

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_money.inc
+++ b/modules/views/civicrm/civicrm_handler_field_money.inc
@@ -43,7 +43,12 @@ class civicrm_handler_field_money extends views_handler_field {
 
   public function render($values) {
     $value = $this->get_value($values);
-    $currency = $this->get_value($values, 'currency');
+    if (!empty($this->definition['currency field'])) {
+      $currency = $this->get_value($values, 'currency');
+    }
+    else {
+      $currency = CRM_Core_Config::singleton()->defaultCurrency;
+    }
 
     switch ($this->options['display_format']) {
       case 'formatted':


### PR DESCRIPTION
* [CRM-20783: undefined currency error when pricefield value is included in view](https://issues.civicrm.org/jira/browse/CRM-20783)