### PR TITLE
CRM-17652: Symfony conflict between Civi and Drupal 8

### DIFF
--- a/civicrm.info.yml
+++ b/civicrm.info.yml
@@ -4,5 +4,3 @@ description: 'Constituent Relationship Management system. Allows sites to manage
 package: CiviCRM
 version: 8.x-4.7
 core: 8.x
-dependencies:
-  -  libraries:libraries

--- a/civicrm.install
+++ b/civicrm.install
@@ -130,11 +130,9 @@ function _civicrm_find_civicrm() {
   }
 
   $path = 'vendor/civicrm/civicrm-core';
-  //if ($path = libraries_get_path('civicrm')) {
-    if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
-      return \Drupal::service('file_system')->realpath($path);
-    }
-  //}
+  if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
+    return \Drupal::service('file_system')->realpath($path);
+  }
 
   return NULL;
 }

--- a/civicrm.install
+++ b/civicrm.install
@@ -129,11 +129,12 @@ function _civicrm_find_civicrm() {
     }
   }
 
-  if ($path = libraries_get_path('civicrm')) {
+  $path = 'vendor/civicrm/civicrm-core';
+  //if ($path = libraries_get_path('civicrm')) {
     if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
       return \Drupal::service('file_system')->realpath($path);
     }
-  }
+  //}
 
   return NULL;
 }

--- a/civicrm.services.yml
+++ b/civicrm.services.yml
@@ -5,7 +5,7 @@ services:
     class: Drupal\civicrm\CivicrmPageState
   civicrm.breadcrumb:
     class: Drupal\civicrm\CivicrmBreadcrumbBuilder
-    arguments: [@string_translation, @civicrm.page_state]
+    arguments: ['@string_translation', '@civicrm.page_state']
     tags:
       - { name: breadcrumb_builder, priority: 1002 }
   civicrm.path_processor:


### PR DESCRIPTION
* [CRM-17652: Symfony conflict between Civi and Drupal 8](https://issues.civicrm.org/jira/browse/CRM-17652)