### PR TITLE
CRM-21016: Allow Drupal views to be used for Notes related to contributions

### DIFF
--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -1139,24 +1139,23 @@ function _civicrm_core_data(&$data, $enabled) {
   civicrm_views_add_fields($fields, $data['civicrm_address'], 'civicrm_address');
 
   // CIVICRM_NOTE table
-
   $data['civicrm_note']['table']['group'] = t('CiviCRM Note');
+  $data['civicrm_note']['table']['join'] = array();
 
-  // Explain how this table joins to others.
-  $data['civicrm_note']['table']['join'] = array(
-    // Directly links to contact table.
-    'civicrm_contact' => array(
+  foreach (array_keys(CRM_Core_BAO_Note::entityTables()) as $entityTable) {
+    // Explain how this table joins to others.
+    $data['civicrm_note']['table']['join'][$entityTable] = array(
       'left_field' => 'id',
       'field' => 'entity_id',
       'extra' => array(
         array(
           'field' => 'entity_table',
-          'value' => 'civicrm_contact',
+          'value' => $entityTable,
           'numeric' => FALSE,
         ),
       ),
-    ),
-  );
+    );
+  }
 
   // NOTE TEXT
   $data['civicrm_note']['note'] = array(


### PR DESCRIPTION
Not only contributions but now note fields will be available for Participant and Relationships.

---

 * [CRM-21016: Allow Drupal views to be used for Notes related to contributions](https://issues.civicrm.org/jira/browse/CRM-21016)