### PR TITLE
Fix issue CRM-20292 - clear cache breaks Views of custom fields.

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -829,6 +829,12 @@ function drush_civicrm_cacheclear() {
     return;
   }
 
+  // Without this, custom fields disappear from views that use them.
+  // Check that the views module is enabled by testing the presence of a function.
+  if (function_exists('views_invalidate_cache')) {
+    views_invalidate_cache();
+  }
+
   drush_log(dt('The CiviCRM cache has been cleared.'), 'ok');
 }
 


### PR DESCRIPTION
Added views_invalidate_cache all to drush cc civicrm. This prevents an issue where clearing cache would prevent civicrm custom fields from appearing in views after drush cc all called.

---

 * [CRM-20292: Drush cc all clears custom fields from Drupal Views](https://issues.civicrm.org/jira/browse/CRM-20292)