### PR TITLE
Apply Environment Indicator colours to CiviCRM menu also.

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -6,6 +6,8 @@ core = 7.x
 project = civicrm
 php = 5.3
 
+scripts[] = js/civicrm-drupal.js
+
 files[] = civicrm.module
 files[] = civicrm.install
 files[] = civicrm_user.inc

--- a/js/civicrm-drupal.js
+++ b/js/civicrm-drupal.js
@@ -1,0 +1,17 @@
+(function ($) {
+
+  // Integrate CiviCRM menu with Environment Indicator.
+  Drupal.behaviors.civicrm_environment_indicator = {
+    attach: function (context, settings) {
+      if (typeof(CRM.config) != 'undefined' && typeof(settings.environment_indicator) != 'undefined' && typeof(settings.environment_indicator['toolbar-color']) != 'undefined') {
+        $('#civicrm-menu', context).css('background-color', settings.environment_indicator['toolbar-color']);
+        $('#civicrm-menu ul', context).css('background-color', settings.environment_indicator['toolbar-color']);
+        $('#civicrm-menu > ul > li > a', context).css('color', settings.environment_indicator['toolbar-text-color']);
+        $('#civicrm-menu .item-list', context).css('background-color', changeColor(settings.environment_indicator['toolbar-color'], 0.15, true));
+        $('#civicrm-menu .item-list', context).css('background-color', changeColor(settings.environment_indicator['toolbar-color'], 0.15, true));
+        $('#civicrm-menu .item-list ul li a', context).css('background-color', settings.environment_indicator['toolbar-color']).css('color', settings.environment_indicator['toolbar-text-color']);
+      };
+    }
+  };
+
+})(jQuery);


### PR DESCRIPTION
[CRM-21103: Make CiviCRM menu respond to Drupal Environment Indicator module if present](https://issues.civicrm.org/jira/browse/CRM-21103)

![image](https://user-images.githubusercontent.com/105608/29696057-849841f8-899a-11e7-82a8-b70cf8f79ede.png)