### PR TITLE
Fixed CRM-20292: removed permission checks for custom data caching in views

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -327,7 +327,8 @@ function civicrm_views_custom_data_cache(&$data, $entity_type, $group_id, $sub_t
     return;
   }
   // From http://forum.civicrm.org/index.php/topic,17658.msg73901.html#msg73901, CRM-7860.
-  $tree = CRM_Core_BAO_CustomGroup::getTree($entity_type, NULL, NULL, $group_id, $sub_type, NULL);
+  // Checking permissions results in bug CRM-20292.
+  $tree = CRM_Core_BAO_CustomGroup::getTree($entity_type, NULL, NULL, $group_id, $sub_type, NULL, TRUE, NULL, FALSE, FALSE);
 
   $join_table = civicrm_views_get_join_table($entity_type);
   foreach ($tree as $groupkey => $current_group) {


### PR DESCRIPTION
Having the permission check breaks views with custom field, (they are broken even in the admin view), unless there is an ACL in place if Drush CC is used on the command line.

Saving any other view as an administrator fixed this.

---

 * [CRM-20292: Drush cc all clears custom fields from Drupal Views](https://issues.civicrm.org/jira/browse/CRM-20292)