### PR TITLE
CRM-21295: Port top-level admin menu link for CiviCRM to Drupal 8

### DIFF
--- a/civicrm.links.menu.yml
+++ b/civicrm.links.menu.yml
@@ -1,0 +1,5 @@
+civicrm.admin_config_civicrm:
+  route_name: civicrm.admin_config_civicrm
+  parent: system.admin_config
+  title: CiviCRM
+  weight: -10

--- a/civicrm.routing.yml
+++ b/civicrm.routing.yml
@@ -10,6 +10,14 @@ civicrm.civicrm_logout:
   requirements:
     _user_is_logged_in: 'TRUE'
 
+civicrm.admin_config_civicrm:
+  path: '/admin/config/civicrm'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'CiviCRM'
+  requirements:
+    _permission: 'access administration pages'
+
 civicrm.user_profile:
   path: '/user/{user}/edit/profile/{profile}'
   defaults:


### PR DESCRIPTION
See [CRM-21295: Port top-level admin menu link for CiviCRM integration to Drupal 8 module](https://issues.civicrm.org/jira/browse/CRM-21295).

## Description

This PR adds a route and menu item to provide a seciton/page within Drupal's administrative pages where CiviCRM modules may place their configuration forms.

**Note:** You'll need to install a module that provides a page/form with a menu item that utilizes `civicrm.admin_config_civicrm` menu item as its parent.

## Remaining Tasks

None.