### PR TITLE
CRM-21310: Civicrm user profile route should be an admin route in Drupal 8

### DIFF
--- a/civicrm.routing.yml
+++ b/civicrm.routing.yml
@@ -22,5 +22,7 @@ civicrm.user_profile:
   path: '/user/{user}/edit/profile/{profile}'
   defaults:
     _form: '\Drupal\civicrm\Form\UserProfile'
+  options:
+    _admin_route: TRUE
   requirements:
     _custom_access: '\Drupal\civicrm\Form\UserProfile::access'


### PR DESCRIPTION
See https://issues.civicrm.org/jira/browse/CRM-21310