### PR TITLE
CRM-19995 - Fix missing 's' in array name

### DIFF
--- a/modules/civicrm_member_roles/civicrm_member_roles.module
+++ b/modules/civicrm_member_roles/civicrm_member_roles.module
@@ -576,7 +576,7 @@ function _civicrm_member_roles_sync($ext_uid = NULL, $cid = NULL, $sync_type = N
       }
       foreach ($memberships['values'] as $key => $membership) {
         if (in_array($membership['status_id'], $inactive)) {
-          unset($membership['values'][$key]);
+          unset($memberships['values'][$key]);
         }
       }
     }


### PR DESCRIPTION
Without the 's', the variable is not an array, and give this error : 
Notice : Undefined offset: 5 dans _civicrm_member_roles_sync() (ligne 587 dans /xxxxxxx/sites/all/modules/civicrm/drupal/modules/civicrm_member_roles/civicrm_member_roles.module).

---

 * [CRM-19995: Notice : Undefined offset: 5 dans _civicrm_member_roles_sync\(\)](https://issues.civicrm.org/jira/browse/CRM-19995)