### PR TITLE
Allow Drupal 8 installations with the vendor directory outside the web root

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -78,7 +78,7 @@ function civicrm_requirements($phase) {
       'title' => 'CiviCRM location',
       'value' => NULL,
       'severity' => REQUIREMENT_ERROR,
-      'description' => 'CiviCRM must be downloaded into the libraries folder.',
+      'description' => 'CiviCRM must be installed via composer.',
     );
     return $requirements;
   }
@@ -119,19 +119,22 @@ function civicrm_requirements($phase) {
  *
  * @return string|void
  *
- * Recommended location for civicrm is in /libraries/civicrm [citation needed].
+ * Installation via composer is recommended.
  * We also allow /modules/civicrm, which seems to work fine.
  */
 function _civicrm_find_civicrm() {
+  $possible_paths = array();
+
   if ($path = drupal_get_path('module', 'civicrm')) {
+    $possible_paths[] = $path;
+  }
+  $possible_paths[] = 'vendor/civicrm/civicrm-core';
+  $possible_paths[] = '../vendor/civicrm/civicrm-core';
+
+  foreach ($possible_paths as $path) {
     if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
       return \Drupal::service('file_system')->realpath($path);
     }
-  }
-
-  $path = 'vendor/civicrm/civicrm-core';
-  if (file_exists($path . '/CRM/Core/ClassLoader.php')) {
-    return \Drupal::service('file_system')->realpath($path);
   }
 
   return NULL;


### PR DESCRIPTION
It's considered best practice with composer to keep the vendor directory outside of the web root, however, this isn't how Drupal 8 is setup by default (in consideration of less technical users and common shared hosting platforms where this isn't possible).

A number of people following the composer instructions I posted on my blog tried installing civicrm with the vendor directory outside the web root and had problems!

This PR will allow the 'civicrm' module to be installed when in this arrangement - however, it doesn't fix all the problems, but the remaining problems are outside of the Drupal module and will need to be addressed in my instructions.

I also took this opportunity to change some of the comments and messages in the civicrm.install file that reference installing CiviCRM in the libraries directory, because that's not how this works any more!