### PR TITLE
Allow adding user entity fields to views, not just columns on the 'users' table

### DIFF
--- a/modules/civicrm_views/civicrm_views.views.inc
+++ b/modules/civicrm_views/civicrm_views.views.inc
@@ -471,6 +471,7 @@ function _civicrm_views_add_implicit_joins(&$data) {
       'users' => array(
         'left_field' => 'uid',
         'field' => 'uf_id',
+        'entity_type' => 'user',
         'extra' => array(
           array(
             'field' => 'domain_id',


### PR DESCRIPTION
Currently, if you make a relationship in Views back to 'Drupal Users' it will only let you add fields for columns on the 'users' table that have Views integration. However, adding this key will tell Views that this is a relationship to the 'user' entity type, which will allow you to add any fields that are on the 'user' entity.