### PR TITLE
CRM-20006 Standard groups relationships in views

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -60,6 +60,7 @@ files[] = modules/views/civicrm/civicrm_handler_filter_custom_option.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_datetime.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_encounter_medium.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_group_status.inc
+files[] = modules/views/civicrm/civicrm_handler_filter_group_name.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_custom_option.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_custom_single_option.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_relationship_type.inc
@@ -97,6 +98,9 @@ files[] = modules/views/civicrm/civicrm_handler_relationship_im.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_website.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_address.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_participant.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_group.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_standard_group.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_standard_group_contact.inc
 
 ; views plugins
 files[] = modules/views/plugins/calendar_plugin_row_civicrm.inc

--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -368,6 +368,19 @@ function civicrm_views_custom_data_cache(&$data, $entity_type, $group_id, $sub_t
           'field' => 'entity_id',
         );
       }
+
+      // Expose group custom data to group relationship.
+      if ($join_table == 'civicrm_group') {
+        $data[$current_group['table_name']]['table']['join']['civicrm_group'] = array(
+          'left_field' => 'id',
+          'field'      => 'entity_id',
+        );
+        $data[$current_group['table_name']]['table']['join']['civicrm_group_contact'] = array(
+          'left_table' => $join_table,
+          'left_field' => 'id',
+          'field'      => 'entity_id',
+        );
+      }
     }
 
     foreach ($current_group['fields'] as $key => $current_field) {

--- a/modules/views/civicrm/civicrm_handler_filter_group_name.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_group_name.inc
@@ -1,7 +1,7 @@
 <?php
 /*
   +--------------------------------------------------------------------+
-  | CiviCRM version 4.7                                                |
+  | CiviCRM version 5                                                  |
   +--------------------------------------------------------------------+
   | This file is a part of CiviCRM.                                    |
   |                                                                    |
@@ -39,14 +39,14 @@ class civicrm_handler_filter_group_name extends views_handler_filter_in_operator
         return;
       }
       $standard_or_smart = ($this->is_standard ? 'IS NULL' : 'IS NOT NULL');
-      $result = civicrm_api3('Group', 'get', array(
-          'return' => array("name", "title"),
-          'is_hidden' => 0,
-          'is_active' => 1,
-          'saved_search_id' => array($standard_or_smart => 1),
-          'options' => array('limit' => 0, 'sort' => "title"),
-      ));
-      $this->civi_groups = array();
+      $result = civicrm_api3('Group', 'get', [
+        'return' => ["name", "title"],
+        'is_hidden' => 0,
+        'is_active' => 1,
+        'saved_search_id' => [$standard_or_smart => 1],
+        'options' => ['limit' => 0, 'sort' => "title"],
+      ]);
+      $this->civi_groups = [];
       foreach ($result['values'] as $group) {
         if (isset($group['name'])) {
           $this->civi_groups[$group['name']] = $group['title'];
@@ -58,7 +58,7 @@ class civicrm_handler_filter_group_name extends views_handler_filter_in_operator
   public function get_value_options() {
     if (!isset($this->value_options)) {
       $this->value_title = t('Contact Group Title');
-      $options = array();
+      $options = [];
       foreach ($this->civi_groups as $name => $title) {
         $options[$name] = $title;
       }

--- a/modules/views/civicrm/civicrm_handler_filter_group_name.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_group_name.inc
@@ -1,0 +1,69 @@
+<?php
+/*
+  +--------------------------------------------------------------------+
+  | CiviCRM version 4.7                                                |
+  +--------------------------------------------------------------------+
+  | This file is a part of CiviCRM.                                    |
+  |                                                                    |
+  | CiviCRM is free software; you can copy, modify, and distribute it  |
+  | under the terms of the GNU Affero General Public License           |
+  | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+  |                                                                    |
+  | CiviCRM is distributed in the hope that it will be useful, but     |
+  | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+  | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+  | See the GNU Affero General Public License for more details.        |
+  |                                                                    |
+  | You should have received a copy of the GNU Affero General Public   |
+  | License and the CiviCRM Licensing Exception along                  |
+  | with this program; if not, contact CiviCRM LLC                     |
+  | at info[AT]civicrm[DOT]org. If you have questions about the        |
+  | GNU Affero General Public License or the licensing of CiviCRM,     |
+  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+  +--------------------------------------------------------------------+
+ */
+
+
+/**
+ * CiviCRM Views Integration
+ */
+class civicrm_handler_filter_group_name extends views_handler_filter_in_operator {
+  private $civi_groups;
+  protected $is_standard = TRUE;
+
+  public function construct() {
+    parent::construct();
+
+    if (empty($this->civi_groups)) {
+      if (!civicrm_initialize()) {
+        return;
+      }
+      $standard_or_smart = ($this->is_standard ? 'IS NULL' : 'IS NOT NULL');
+      $result = civicrm_api3('Group', 'get', array(
+          'return' => array("name", "title"),
+          'is_hidden' => 0,
+          'is_active' => 1,
+          'saved_search_id' => array($standard_or_smart => 1),
+          'options' => array('limit' => 0, 'sort' => "title"),
+      ));
+      $this->civi_groups = array();
+      foreach ($result['values'] as $group) {
+        if (isset($group['name'])) {
+          $this->civi_groups[$group['name']] = $group['title'];
+        }
+      }
+    }
+  }
+
+  public function get_value_options() {
+    if (!isset($this->value_options)) {
+      $this->value_title = t('Contact Group Title');
+      $options = array();
+      foreach ($this->civi_groups as $name => $title) {
+        $options[$name] = $title;
+      }
+      $this->value_options = $options;
+    }
+  }
+
+}

--- a/modules/views/civicrm/civicrm_handler_relationship_group.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_group.inc
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * This relationship handler is used when joining the civicrm_group_contact table
+ * to the civicrm_contact table. This handler allows us to optionally add conditions
+ * to the join clause based on group_id, status, group title, is_active, group is standard group.
+ */
+class civicrm_handler_relationship_group extends views_handler_relationship {
+  static $civi_group_types;
+  private $civi_groups;
+  protected $is_standard;
+
+  /**
+   * Preload the list of group_types & titles and store in the static variables
+   */
+  public function construct() {
+    parent::construct();
+
+    if (!civicrm_initialize()) {
+      return;
+    }
+
+    self::$civi_group_types = CRM_Contact_BAO_Group::buildOptions('group_type');
+
+    $standard_or_smart = ($this->is_standard ? 'IS NULL' : 'IS NOT NULL');
+    $result = civicrm_api3('Group', 'get', array(
+        'return' => array("name", "title", "group_type"),
+        'is_hidden' => 0,
+        'is_active' => 1,
+        'saved_search_id' => array($standard_or_smart => 1),
+        'options' => array('limit' => 0, 'sort' => "title"),
+    ));
+    $this->civi_groups = array();
+    foreach ($result['values'] as $group) {
+      $group_types = array();
+      if (!empty($group['group_type'])) {
+        foreach ((array) $group['group_type'] as $type) {
+          if (!empty($type)) {
+            $group_types[] = (isset(self::$civi_group_types[$type]) ? self::$civi_group_types[$type] : $type);
+          }
+        }
+      }
+
+      if (isset($group['name'])) {
+        $group_type = '';
+        if (!empty($group_types)) {
+          $group_type = implode(', ', $group_types);
+        }
+        $this->civi_groups[$group['name']] = $group['title'] . ' | ' . $group_type;
+      }
+    }
+  }
+
+
+  /**
+   * Add additional options
+   * to the view. By defining these here, Views will take care of saving the
+   * values submitted from the options form.
+   */
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options['civi_group_type'] = array('default' => NULL);
+    $options['civi_group_name'] = array('default' => NULL);
+    return $options;
+  }
+
+  /**
+   * Relationship configuration form.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $form['civi_group_type'] = array(
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#title' => 'Choose a specific group type',
+      '#options' => self::$civi_group_types,
+      '#description' => t('Choose to limit this relationship to one or more specific types of CiviCRM group.'),
+      '#default_value' => $this->options['civi_group_type'],
+    );
+    $form['civi_group_name'] = array(
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#title' => 'Choose a specific group',
+      '#options' => $this->civi_groups,
+      '#description' => t('Choose to limit this relationship to one or more specific CiviCRM groups.'),
+      '#default_value' => $this->options['civi_group_name'],
+    );
+  }
+
+
+  public function join_required($join = array()) {
+    if (!empty($this->options['required'])) {
+      $join->type = 'INNER';
+    }
+    return $join;
+  }
+
+
+  public function join_group_type($join = array()) {
+    $extra = array();
+    if (isset($join->extra)) {
+      $extra = $join->extra;
+    }
+    if (isset($this->options['civi_group_type']) && $this->options['civi_group_type']) {
+      $sep = CRM_Core_DAO::VALUE_SEPARATOR;
+
+      $extra[] = array(
+        'value' => "($sep" . implode("$sep|$sep", $this->options['civi_group_type']) . "$sep)",
+        'numeric' => FALSE,
+        'field' => 'group_type',
+        'operator' => 'RLIKE',
+      );
+    }
+    if (!empty($extra)) {
+      $join->extra = $extra;
+    }
+    return $join;
+  }
+
+  public function join_group_name($join = array()) {
+    $extra = array();
+    if (isset($join->extra)) {
+      $extra = $join->extra;
+    }
+    if (isset($this->options['civi_group_name']) && $this->options['civi_group_name']) {
+      $extra[] = array(
+        'value' => $this->options['civi_group_name'],
+        'numeric' => FALSE,
+        'field' => 'name',
+      );
+    }
+    if (!empty($extra)) {
+      $join->extra = $extra;
+    }
+    return $join;
+  }
+
+
+  public function join_group_active_not_hidden($join = array()) {
+    $extra = array();
+    if (isset($join->extra)) {
+      $extra = $join->extra;
+    }
+    $extra[] = array(
+      'value' => 1,
+      'numeric' => TRUE,
+      'field' => 'is_active',
+    );
+    $extra[] = array(
+      'value' => 0,
+      'numeric' => TRUE,
+      'field' => 'is_hidden',
+    );
+
+    $join->extra = $extra;
+    return $join;
+  }
+
+  public function get_join() {
+    $join = parent::get_join();
+    $join = $this->join_group_active_not_hidden($join);
+    $join = $this->join_required($join);
+    $join = $this->join_group_type($join);
+    $join = $this->join_group_name($join);
+    return $join;
+  }
+
+
+  /**
+   * Called to implement a relationship in a query.
+   */
+  public function query() {
+    $join = $this->get_join();
+    $this->alias = $this->query->add_table($this->table, $this->relationship, $join);
+    //register relationship
+    $this->view->relationship[$this->options['id']]->alias = $this->alias;
+    $this->query->relationships[$this->alias] = array(
+      'link' => $this->relationship,
+      'table' => $this->table,
+      'base' => $this->table,
+    );
+
+  }
+
+}

--- a/modules/views/civicrm/civicrm_handler_relationship_group.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_group.inc
@@ -6,7 +6,7 @@
  * to the join clause based on group_id, status, group title, is_active, group is standard group.
  */
 class civicrm_handler_relationship_group extends views_handler_relationship {
-  static $civi_group_types;
+  public static $civi_group_types;
   private $civi_groups;
   protected $is_standard;
 
@@ -23,16 +23,16 @@ class civicrm_handler_relationship_group extends views_handler_relationship {
     self::$civi_group_types = CRM_Contact_BAO_Group::buildOptions('group_type');
 
     $standard_or_smart = ($this->is_standard ? 'IS NULL' : 'IS NOT NULL');
-    $result = civicrm_api3('Group', 'get', array(
-        'return' => array("name", "title", "group_type"),
-        'is_hidden' => 0,
-        'is_active' => 1,
-        'saved_search_id' => array($standard_or_smart => 1),
-        'options' => array('limit' => 0, 'sort' => "title"),
-    ));
-    $this->civi_groups = array();
+    $result = civicrm_api3('Group', 'get', [
+      'return' => ["name", "title", "group_type"],
+      'is_hidden' => 0,
+      'is_active' => 1,
+      'saved_search_id' => [$standard_or_smart => 1],
+      'options' => ['limit' => 0, 'sort' => "title"],
+    ]);
+    $this->civi_groups = [];
     foreach ($result['values'] as $group) {
-      $group_types = array();
+      $group_types = [];
       if (!empty($group['group_type'])) {
         foreach ((array) $group['group_type'] as $type) {
           if (!empty($type)) {
@@ -51,7 +51,6 @@ class civicrm_handler_relationship_group extends views_handler_relationship {
     }
   }
 
-
   /**
    * Add additional options
    * to the view. By defining these here, Views will take care of saving the
@@ -59,8 +58,8 @@ class civicrm_handler_relationship_group extends views_handler_relationship {
    */
   public function option_definition() {
     $options = parent::option_definition();
-    $options['civi_group_type'] = array('default' => NULL);
-    $options['civi_group_name'] = array('default' => NULL);
+    $options['civi_group_type'] = ['default' => NULL];
+    $options['civi_group_name'] = ['default' => NULL];
     return $options;
   }
 
@@ -70,47 +69,45 @@ class civicrm_handler_relationship_group extends views_handler_relationship {
   public function options_form(&$form, &$form_state) {
     parent::options_form($form, $form_state);
 
-    $form['civi_group_type'] = array(
+    $form['civi_group_type'] = [
       '#type' => 'select',
       '#multiple' => TRUE,
       '#title' => 'Choose a specific group type',
       '#options' => self::$civi_group_types,
       '#description' => t('Choose to limit this relationship to one or more specific types of CiviCRM group.'),
       '#default_value' => $this->options['civi_group_type'],
-    );
-    $form['civi_group_name'] = array(
+    ];
+    $form['civi_group_name'] = [
       '#type' => 'select',
       '#multiple' => TRUE,
       '#title' => 'Choose a specific group',
       '#options' => $this->civi_groups,
       '#description' => t('Choose to limit this relationship to one or more specific CiviCRM groups.'),
       '#default_value' => $this->options['civi_group_name'],
-    );
+    ];
   }
 
-
-  public function join_required($join = array()) {
+  public function join_required($join = []) {
     if (!empty($this->options['required'])) {
       $join->type = 'INNER';
     }
     return $join;
   }
 
-
-  public function join_group_type($join = array()) {
-    $extra = array();
+  public function join_group_type($join = []) {
+    $extra = [];
     if (isset($join->extra)) {
       $extra = $join->extra;
     }
     if (isset($this->options['civi_group_type']) && $this->options['civi_group_type']) {
       $sep = CRM_Core_DAO::VALUE_SEPARATOR;
 
-      $extra[] = array(
+      $extra[] = [
         'value' => "($sep" . implode("$sep|$sep", $this->options['civi_group_type']) . "$sep)",
         'numeric' => FALSE,
         'field' => 'group_type',
         'operator' => 'RLIKE',
-      );
+      ];
     }
     if (!empty($extra)) {
       $join->extra = $extra;
@@ -118,17 +115,17 @@ class civicrm_handler_relationship_group extends views_handler_relationship {
     return $join;
   }
 
-  public function join_group_name($join = array()) {
-    $extra = array();
+  public function join_group_name($join = []) {
+    $extra = [];
     if (isset($join->extra)) {
       $extra = $join->extra;
     }
     if (isset($this->options['civi_group_name']) && $this->options['civi_group_name']) {
-      $extra[] = array(
+      $extra[] = [
         'value' => $this->options['civi_group_name'],
         'numeric' => FALSE,
         'field' => 'name',
-      );
+      ];
     }
     if (!empty($extra)) {
       $join->extra = $extra;
@@ -136,22 +133,21 @@ class civicrm_handler_relationship_group extends views_handler_relationship {
     return $join;
   }
 
-
-  public function join_group_active_not_hidden($join = array()) {
-    $extra = array();
+  public function join_group_active_not_hidden($join = []) {
+    $extra = [];
     if (isset($join->extra)) {
       $extra = $join->extra;
     }
-    $extra[] = array(
+    $extra[] = [
       'value' => 1,
       'numeric' => TRUE,
       'field' => 'is_active',
-    );
-    $extra[] = array(
+    ];
+    $extra[] = [
       'value' => 0,
       'numeric' => TRUE,
       'field' => 'is_hidden',
-    );
+    ];
 
     $join->extra = $extra;
     return $join;
@@ -166,7 +162,6 @@ class civicrm_handler_relationship_group extends views_handler_relationship {
     return $join;
   }
 
-
   /**
    * Called to implement a relationship in a query.
    */
@@ -175,11 +170,11 @@ class civicrm_handler_relationship_group extends views_handler_relationship {
     $this->alias = $this->query->add_table($this->table, $this->relationship, $join);
     //register relationship
     $this->view->relationship[$this->options['id']]->alias = $this->alias;
-    $this->query->relationships[$this->alias] = array(
+    $this->query->relationships[$this->alias] = [
       'link' => $this->relationship,
       'table' => $this->table,
       'base' => $this->table,
-    );
+    ];
 
   }
 

--- a/modules/views/civicrm/civicrm_handler_relationship_standard_group.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_standard_group.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This relationship handler is used when joining the civicrm_group_contact table
+ * to the civicrm_contact table. This handler allows us to optionally add conditions
+ * to the join clause based on group_id, status, group title, is_active, group is standard group.
+ */
+class civicrm_handler_relationship_standard_group extends civicrm_handler_relationship_group {
+
+  public function construct() {
+    $this->is_standard = TRUE;
+    parent::construct();
+  }
+
+}

--- a/modules/views/civicrm/civicrm_handler_relationship_standard_group_contact.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_standard_group_contact.inc
@@ -6,9 +6,9 @@
  * to the join clause based on group_id, status, group title, is_active, group is standard group.
  */
 class civicrm_handler_relationship_standard_group_contact extends views_handler_relationship {
-  static $group_status;
-  private $group_ids = array();
-  private $group_titles = array();
+  public static $group_status;
+  private $group_ids = [];
+  private $group_titles = [];
 
   /**
    * Preload the list of group_types & titles and store in the static variables
@@ -24,13 +24,13 @@ class civicrm_handler_relationship_standard_group_contact extends views_handler_
       self::$group_status = CRM_Contact_BAO_GroupContact::buildOptions('status');
     }
 
-    $result = civicrm_api3('Group', 'get', array(
-        'return' => array("name", "title"),
-        'is_hidden' => 0,
-        'is_active' => 1,
-        'saved_search_id' => array('IS NULL' => 1),
-        'options' => array('limit' => 0, 'sort' => "title"),
-    ));
+    $result = civicrm_api3('Group', 'get', [
+      'return' => ["name", "title"],
+      'is_hidden' => 0,
+      'is_active' => 1,
+      'saved_search_id' => ['IS NULL' => 1],
+      'options' => ['limit' => 0, 'sort' => "title"],
+    ]);
     foreach ($result['values'] as $group) {
       if (isset($group['name'])) {
         $this->group_ids[$group['name']] = $group['id'];
@@ -46,8 +46,8 @@ class civicrm_handler_relationship_standard_group_contact extends views_handler_
    */
   public function option_definition() {
     $options = parent::option_definition();
-    $options['group_status'] = array('default' => 'Added');
-    $options['group_names'] = array('default' => NULL);
+    $options['group_status'] = ['default' => 'Added'];
+    $options['group_names'] = ['default' => NULL];
     return $options;
   }
 
@@ -57,53 +57,53 @@ class civicrm_handler_relationship_standard_group_contact extends views_handler_
   public function options_form(&$form, &$form_state) {
     parent::options_form($form, $form_state);
 
-    $form['group_status'] = array(
+    $form['group_status'] = [
       '#type' => 'select',
       '#multiple' => TRUE,
       '#title' => 'Choose a specific group status',
       '#options' => self::$group_status,
       '#description' => t('Choose to limit this relationship to one or more specific status of CiviCRM group.'),
       '#default_value' => $this->options['group_status'],
-    );
-    $form['group_names'] = array(
+    ];
+    $form['group_names'] = [
       '#type' => 'select',
       '#multiple' => TRUE,
       '#title' => 'Choose a specific group',
       '#options' => $this->group_titles,
       '#description' => t('Choose to limit this relationship to one or more specific CiviCRM groups.'),
       '#default_value' => $this->options['group_names'],
-    );
+    ];
   }
 
-  public function join_required($join = array()) {
+  public function join_required($join = []) {
     if (!empty($this->options['required'])) {
       $join->type = 'INNER';
     }
     return $join;
   }
 
-  public function join_group_contact($join = array()) {
-    $extra = array();
+  public function join_group_contact($join = []) {
+    $extra = [];
     if (isset($join->extra)) {
       $extra = $join->extra;
     }
     if (!empty($this->options['group_status'])) {
-      $extra[] = array(
+      $extra[] = [
         'value' => $this->options['group_status'],
         'numeric' => FALSE,
         'field' => 'status',
-      );
+      ];
     }
     if (!empty($this->options['group_names'])) {
-      $values = array();
+      $values = [];
       foreach (array_keys($this->options['group_names']) as $name) {
         $values[] = $this->group_ids[$name];
       }
-      $extra[] = array(
+      $extra[] = [
         'value' => $values,
         'numeric' => TRUE,
         'field' => 'group_id',
-      );
+      ];
     }
     if (!empty($extra)) {
       $join->extra = $extra;
@@ -126,11 +126,11 @@ class civicrm_handler_relationship_standard_group_contact extends views_handler_
     $this->alias = $this->query->add_table($this->table, $this->relationship, $join);
     //register relationship
     $this->view->relationship[$this->options['id']]->alias = $this->alias;
-    $this->query->relationships[$this->alias] = array(
+    $this->query->relationships[$this->alias] = [
       'link' => $this->relationship,
       'table' => $this->table,
       'base' => $this->table,
-    );
+    ];
   }
 
 }

--- a/modules/views/civicrm/civicrm_handler_relationship_standard_group_contact.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_standard_group_contact.inc
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * This relationship handler is used when joining the civicrm_group_contact table
+ * to the civicrm_contact table. This handler allows us to optionally add conditions
+ * to the join clause based on group_id, status, group title, is_active, group is standard group.
+ */
+class civicrm_handler_relationship_standard_group_contact extends views_handler_relationship {
+  static $group_status;
+  private $group_ids = array();
+  private $group_titles = array();
+
+  /**
+   * Preload the list of group_types & titles and store in the static variables
+   */
+  public function construct() {
+    parent::construct();
+
+    if (!civicrm_initialize()) {
+      return;
+    }
+
+    if (empty(self::$group_status)) {
+      self::$group_status = CRM_Contact_BAO_GroupContact::buildOptions('status');
+    }
+
+    $result = civicrm_api3('Group', 'get', array(
+        'return' => array("name", "title"),
+        'is_hidden' => 0,
+        'is_active' => 1,
+        'saved_search_id' => array('IS NULL' => 1),
+        'options' => array('limit' => 0, 'sort' => "title"),
+    ));
+    foreach ($result['values'] as $group) {
+      if (isset($group['name'])) {
+        $this->group_ids[$group['name']] = $group['id'];
+        $this->group_titles[$group['name']] = $group['title'];
+      }
+    }
+  }
+
+  /**
+   * Add additional options
+   * to the view. By defining these here, Views will take care of saving the
+   * values submitted from the options form.
+   */
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options['group_status'] = array('default' => 'Added');
+    $options['group_names'] = array('default' => NULL);
+    return $options;
+  }
+
+  /**
+   * Relationship configuration form.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $form['group_status'] = array(
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#title' => 'Choose a specific group status',
+      '#options' => self::$group_status,
+      '#description' => t('Choose to limit this relationship to one or more specific status of CiviCRM group.'),
+      '#default_value' => $this->options['group_status'],
+    );
+    $form['group_names'] = array(
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#title' => 'Choose a specific group',
+      '#options' => $this->group_titles,
+      '#description' => t('Choose to limit this relationship to one or more specific CiviCRM groups.'),
+      '#default_value' => $this->options['group_names'],
+    );
+  }
+
+  public function join_required($join = array()) {
+    if (!empty($this->options['required'])) {
+      $join->type = 'INNER';
+    }
+    return $join;
+  }
+
+  public function join_group_contact($join = array()) {
+    $extra = array();
+    if (isset($join->extra)) {
+      $extra = $join->extra;
+    }
+    if (!empty($this->options['group_status'])) {
+      $extra[] = array(
+        'value' => $this->options['group_status'],
+        'numeric' => FALSE,
+        'field' => 'status',
+      );
+    }
+    if (!empty($this->options['group_names'])) {
+      $values = array();
+      foreach (array_keys($this->options['group_names']) as $name) {
+        $values[] = $this->group_ids[$name];
+      }
+      $extra[] = array(
+        'value' => $values,
+        'numeric' => TRUE,
+        'field' => 'group_id',
+      );
+    }
+    if (!empty($extra)) {
+      $join->extra = $extra;
+    }
+    return $join;
+  }
+
+  public function get_join() {
+    $join = parent::get_join();
+    $join = $this->join_required($join);
+    $join = $this->join_group_contact($join);
+    return $join;
+  }
+
+  /**
+   * Called to implement a relationship in a query.
+   */
+  public function query() {
+    $join = $this->get_join();
+    $this->alias = $this->query->add_table($this->table, $this->relationship, $join);
+    //register relationship
+    $this->view->relationship[$this->options['id']]->alias = $this->alias;
+    $this->query->relationships[$this->alias] = array(
+      'link' => $this->relationship,
+      'table' => $this->table,
+      'base' => $this->table,
+    );
+  }
+
+}

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -2797,6 +2797,22 @@ function _civicrm_core_data(&$data, $enabled) {
   }
 
   // Add support for CivicRM groups table
+  $data['civicrm_group_contact']['table']['group'] = t('CiviCRM Groups');
+
+  $data['civicrm_group_contact']['table']['join']['civicrm_contact'] = array(
+    'left_field' => 'id',
+    'field' => 'contact_id',
+  );
+
+  $data['civicrm_contact']['table']['join']['civicrm_group_contact'] = array(
+    'left_field' => 'contact_id',
+    'field' => 'id',
+  );
+
+  $data['civicrm_group_contact']['table']['join']['civicrm_group_contact'] = array(
+    'left_field' => 'id',
+    'field' => 'id',
+  );
 
   $data['civicrm_group']['table']['group'] = t('CiviCRM Groups');
 
@@ -2806,51 +2822,58 @@ function _civicrm_core_data(&$data, $enabled) {
     'help' => t("View displays CiviCRM Groups."),
   );
 
+  $data['civicrm_group']['table']['join']['civicrm_contact_contact'] = array(
+    'left_field' => 'group_id',
+    'field' => 'id',
+  );
+
+  $data['civicrm_group_contact']['table']['join']['civicrm_group'] = array(
+    // Directly links to group table
+    'left_field' => 'id',
+    'field' => 'group_id',
+  );
+
+  $data['civicrm_group']['table']['join']['civicrm_group'] = array(
+    'left_field' => 'id',
+    'field' => 'id',
+  );
+
   $data['civicrm_group']['table']['join']['civicrm_contact'] = array(
     'left_table' => 'civicrm_group_contact',
     'left_field' => 'group_id',
     'field' => 'id',
   );
 
-  $data['civicrm_group_contact']['table']['join']['civicrm_contact'] = array(
-    // Directly links to group table
-    'left_field' => 'id',
-    'field' => 'contact_id',
-  );
-
-  $data['civicrm_group_contact']['table']['group'] = t('CiviCRM Groups');
-  $data['civicrm_group_status']['table']['group'] = t('Contact Group Status');
-
-  $data['civicrm_group_contact']['status'] = array(
-    'title' => t('Contact Status'),
-    'help' => t('The group status of the contact'),
-    'field' => array(
-      'handler' => 'civicrm_handler_filter_group_status',
-      'click sortable' => TRUE,
-    ),
-    'filter' => array(
-      'handler' => 'civicrm_handler_filter_group_status',
-      'allow empty' => TRUE,
-    ),
-  );
-
   // CiviCRM Groups - FIELDS
-
-  // Numeric Group ID
+  //Group Contact ID
+  $data['civicrm_group_contact']['id'] = array(
+    'title' => t('Contact in Standard Group'),
+    'help' => t('The contact is part of a standard group'),
+    'relationship' => array(
+      'base' => 'civicrm_contact',
+      'base field' => 'id',
+      'relationship table' => 'civicrm_group_contact',
+      'relationship field' => 'contact_id',
+      'handler' => 'civicrm_handler_relationship_standard_group_contact',
+      'label' => t('CiviCRM Standard Group Contact'),
+    ),
+  );
+  // Group Status
   $data['civicrm_group_contact']['status'] = array(
     'title' => t('Contact Status'),
     'help' => t('The group status of the contact'),
     'field' => array(
-      'handler' => 'civicrm_handler_filter_group_status',
+      'handler' => 'civicrm_handler_field_pseudo_constant',
       'click sortable' => TRUE,
+      'pseudo class' => 'CRM_Contact_BAO_GroupContact',
+      'pseudo method' => 'buildOptions',
+      'pseudo args' => array('status'),
     ),
     'filter' => array(
       'handler' => 'civicrm_handler_filter_group_status',
       'allow empty' => TRUE,
     ),
   );
-
-  //CiviCRM Groups - FIELDS
 
   //Numeric Group ID
   $data['civicrm_group']['id'] = array(
@@ -2871,7 +2894,16 @@ function _civicrm_core_data(&$data, $enabled) {
     'sort' => array(
       'handler' => 'views_handler_sort',
     ),
+    'relationship' => array(
+      'base' => 'civicrm_group_contact',
+      'base field' => 'group_id',
+      'relationship table' => 'civicrm_group',
+      'relationship field' => 'id',
+      'handler' => 'civicrm_handler_relationship_standard_group',
+      'label' => t('CiviCRM Group'),
+    ),
   );
+
   //Is Group Active?
   $data['civicrm_group']['is_active'] = array(
     'title' => t('Is Active'),
@@ -2891,8 +2923,23 @@ function _civicrm_core_data(&$data, $enabled) {
     ),
   );
 
+  $data['civicrm_group']['name'] = array(
+    'title' => t('Machine Name'),
+    'help' => t('Group Machine Name'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_group_name',
+    ),
+  );
+
   $data['civicrm_group']['title'] = array(
-    'title' => t('Title'),
+    'title' => t('Title [Deprecated - Use Name or new Title]'),
     'help' => t('Group Title'),
     'real field' => 'id',
     'field' => array(
@@ -2913,6 +2960,23 @@ function _civicrm_core_data(&$data, $enabled) {
       'handler' => 'views_handler_sort',
     ),
   );
+
+  $data['civicrm_group']['title_'] = array(
+    'title' => t('Title'),
+    'help' => t('Group Title'),
+    'real field' => 'title',
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument',
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+  );
+
   $data['civicrm_group']['description'] = array(
     'title' => t('Description'),
     'help' => t('Description of the Group'),

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -2972,6 +2972,10 @@ function _civicrm_core_data(&$data, $enabled) {
     'argument' => array(
       'handler' => 'views_handler_argument',
     ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+      'allow empty' => TRUE,
+    ),
     'sort' => array(
       'handler' => 'views_handler_sort',
     ),


### PR DESCRIPTION
- Expose standard group contact Relationship and be able to filter on status
- Expose standard group Relationship for active and non hidden groups, and be able to filter on type and name
- fix bug preventing to use the field 'group status'
- add filter on group name (for cross-sites export)
- Expose group custom data to group relationship.

@jitendrapurohit this is a re-submit of https://github.com/civicrm/civicrm-drupal/pull/427 are you able to re-test?

---

 * [CRM-20006: Drupal Views : relationships for standard groups](https://issues.civicrm.org/jira/browse/CRM-20006)