### PR TITLE
CRM-21226: Add view filter handler for contact reference custom field

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -66,6 +66,7 @@ files[] = modules/views/civicrm/civicrm_handler_filter_relationship_type.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_country_multi.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_state_multi.inc
 files[] = modules/views/civicrm/civicrm_handler_filter_domain.inc
+files[] = modules/views/civicrm/civicrm_handler_filter_contact_ref.inc
 
 ; activity handlers
 files[] = modules/views/civicrm/civicrm_handler_field_activity.inc

--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -611,6 +611,9 @@ function civicrm_views_get_filter($data_type, $html_type = NULL, $option_group_i
     case "County":
       return array('handler' => 'civicrm_handler_filter_pseudo_constant', 'pseudo class' => 'CRM_Core_PseudoConstant', 'pseudo method' => 'county', 'allow empty' => TRUE);
 
+    case "ContactReference":
+      return array('handler' => 'civicrm_handler_filter_contact_ref');
+
     default:
       return array('handler' => 'views_handler_filter_string', 'allow empty' => TRUE);
   }

--- a/modules/views/civicrm/civicrm_handler_filter_contact_ref.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_contact_ref.inc
@@ -1,0 +1,64 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Filters Contact reference custom field.
+ */
+class civicrm_handler_filter_contact_ref extends views_handler_filter_string {
+  public function construct() {
+    parent::construct();
+    if (!civicrm_initialize()) {
+      return;
+    }
+  }
+  public function op_equal($field) {
+    $this->filterContactRef($field);
+  }
+  public function op_contains($field) {
+    $this->filterContactRef($field);
+  }
+
+  /**
+   * Adds where clause to the view query to filter
+   * by contact sort_name instead of id.
+   *
+   * @param string $field
+   */
+  public function filterContactRef($field) {
+    if (!empty($this->value)) {
+      $op = $this->operator;
+      if ($this->operator != '=' && $this->operator != '!=') {
+        $op = 'LIKE';
+        $this->value = "%{$this->value}%";
+      }
+      $contacts = db_select('civicrm_contact', 'cc')
+        ->fields('cc', array('id'))
+        ->condition('cc.sort_name', $this->value, $op);
+
+      $this->query->add_where($this->options['group'], $field, $contacts, 'IN');
+    }
+  }
+
+}


### PR DESCRIPTION
View contact ref for custom fields don't consider `sort_name` for filtering the results. It checks on the basis of contact id. See jira for more details and steps to replicate this issue. This PR contains fix for `equal to`, `not equal to` and `contains` operator in exposed filter.
 
* [CRM-21226: Add view filter handler for contact reference custom field](https://issues.civicrm.org/jira/browse/CRM-21226)