### PR TITLE
Disable Drupal page and render cache on CiviCRM pages

### DIFF
--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -57,6 +57,9 @@ class CivicrmController extends ControllerBase {
     // been taken care of.
     $build = array(
       '#markup' => Markup::create($content),
+      '#cache' => [
+        'max-age' => 0,
+      ],
     );
 
     // Override default title value if one has been set in the course

--- a/src/Controller/CivicrmController.php
+++ b/src/Controller/CivicrmController.php
@@ -39,6 +39,9 @@ class CivicrmController extends ControllerBase {
     // to an environment variable.
     $_GET['q'] = implode('/', $args);
 
+    // Need to disable the page cache.
+    \Drupal::service('page_cache_kill_switch')->trigger();
+
     // @Todo: Enable CiviCRM's CRM_Core_TemporaryErrorScope::useException() and possibly catch exceptions.
     // At the moment, civicrm doesn't allow exceptions to bubble up to Drupal. See CRM-15022.
     $content = $this->civicrm->invoke($args);


### PR DESCRIPTION
Drupal 8 will try to cache each render array or page if it concludes that the sum of all the parts are cacheable. When logged in, due to some bugs in the admin menu, it won't cache anything, so the backend is largely unaffected (but this will eventually be fixed!). However, when visiting public CiviCRM pages (like contribution pages) as an anonymous user, Drupal will cache them.

And because CiviCRM doesn't give cache contexts, it will actually return same cached contribution page always (ie. if you visit id=1 first, then it will always return that same page, even on id=2). CiviCRM could give a cache context of `url.query_args` to make a different cached version for each combination of query arguments, but... CiviCRM also doesn't give any cache tags (or trigger clearing on any tags) so, once cached, the pages won't change even if the contribution page is changed on the backend.

A complete solution would involve giving all the cache contexts for everything a page could vary on and cache tags for every CiviCRM entity that is present on that page (as well as triggering clearing of those tags when that entity changes) but I'm really not sure how we'd do that without adding a new CiviCRM core API that mimicks the Drupal 8 caching API.

So, for now, let's just disable Drupal page and render caching on all CiviCRM pages!
  