### PR TITLE
CRM-21689 - civicrm rules - cannot select contact from data selector

### DIFF
--- a/modules/civicrm_rules/civicrm_rules_action.inc
+++ b/modules/civicrm_rules/civicrm_rules_action.inc
@@ -63,7 +63,7 @@ The content of the email is:
   $defaults = array(
     'parameter' => array(
       'contact' => array(
-        'type' => 'contact',
+        'type' => 'civicrm_contact',
         'label' => t('Contact'),
         'save' => TRUE,
       ),


### PR DESCRIPTION
* [CRM-21689: civicrm rules - cannot select contact from data selector](https://issues.civicrm.org/jira/browse/CRM-21689)