### PR TITLE
Update civicrm_handler_field_contact_image.inc

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_contact_image.inc
+++ b/modules/views/civicrm/civicrm_handler_field_contact_image.inc
@@ -86,6 +86,7 @@ class civicrm_handler_field_contact_image extends views_handler_field {
       '#dependency' => array(
         'edit-options-url-only' => array(0),
       ),
+            '#prefix' => t('If you do not see Drupal image styles here, it may be worth checking CiviCRM "Custom files directory" <br> at <strong>"CiviCRM > Administer > System Settings > Directories" </strong> : it <strong>has to </strong> contain <italic>[civicrm.files]</italic> token'), 
     );
 
     $form['height'] = array(


### PR DESCRIPTION
Gives "Notice: Undefined index: image_style in civicrm_handler_field_contact_image->render() (line 130 of sites\all\modules\civicrm\drupal\modules\views\civicrm\civicrm_handler_field_contact_image.inc)." if "Custom Files Directory" at civicrm/admin/setting/path?reset=1 doesn't contain "[civicrm.files]" ( in my case default directory has been set as "custom/"  only; changing it to be [civicrm.files]/custom has got Drupal image styles back for CiviCRM Contact Image field in Views )