### PR TITLE
Fix issue CRM-16541

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -1177,6 +1177,7 @@ function drush_civicrm_pre_civicrm_sqldump() {
  * Implementation of command 'civicrm-sql-dump'
  */
 function drush_civicrm_sqldump() {
+  drush_set_option('extra','--routines');
   if (version_compare(DRUSH_VERSION, 7, '>=')) {
     drush_sql_dump();
   }


### PR DESCRIPTION
Referring to [CRM-16541](https://issues.civicrm.org/jira/browse/CRM-16541). Simply uses the drush sql-dump --extra option to add --routines to the mysqldump command. 