### PR TITLE
CRM-21758: Add created_id to Views integration

### DIFF
--- a/modules/views/components/civicrm.event.inc
+++ b/modules/views/components/civicrm.event.inc
@@ -343,6 +343,31 @@ function _civicrm_event_data(&$data, $enabled) {
       'handler' => 'views_handler_sort',
     ),
   );
+  // Event created_id
+  $data['civicrm_event']['created_id'] = array(
+    'title' => t('Created ID'),
+    'help' => t("Contact ID of the event's creator"),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_event_link',
+      'click sortable' => TRUE,
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_numeric',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_numeric',
+      'allow empty' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+    'relationship' => array(
+      'base' => 'civicrm_contact',
+      'field' => 'created_id',
+      'handler' => 'views_handler_relationship',
+      'label' => t('CiviCRM Contact of the event creator'),
+    ),
+  );
   // Link to Campaign Table
   if (isset($enabled['CiviCampaign'])) {
     $data['civicrm_event']['campaign_id'] = array(


### PR DESCRIPTION
## Overview

It's not possible to add the field "created_id" to a View displaying items of type CiviCRM Event.  While it's possible with `civicrm_entity`, this won't provide a relationship to Contact entities.  With this patch, you can create views that only show the events created by the logged-in user.

## Before
`created_id` is not accessible to Views.

## After
`created_id` is accessible to Views.

---

 * [CRM-21758: Add event "created_id" to Drupal Views](https://issues.civicrm.org/jira/browse/CRM-21758)