### PR TITLE
CRM-21818: set timezone when initializing civicrm

### DIFF
--- a/src/Civicrm.php
+++ b/src/Civicrm.php
@@ -49,7 +49,7 @@ class Civicrm {
     }
 
     // Initialize the system by creating a config object
-    \CRM_Core_Config::singleton();
+    \CRM_Core_Config::singleton()->userSystem->setMySQLTimeZone();
 
     // Mark CiviCRM as initialized.
     $this->initialized = TRUE;


### PR DESCRIPTION
**JIRA Issue:** https://issues.civicrm.org/jira/browse/CRM-21818

It seems as though the timezone handling was omitted when porting to Drupal 8.

See the [Drupal 7 implementation](https://github.com/civicrm/civicrm-drupal/blob/7.x-master/civicrm.module#L223.).
