### PR TITLE
civicrm.config.php.drupal: fix logic to find the civicrm.settings.php…

### DIFF
--- a/civicrm.config.php.drupal
+++ b/civicrm.config.php.drupal
@@ -32,33 +32,95 @@
  * 10. $confdir/default
  *
  */
-
 function civicrm_conf_init() {
-    global $skipConfigError;
+  global $skipConfigError;
 
-    static $conf = '';
+  static $conf = '';
 
-    if ($conf) {
-        return $conf;
+  if ($conf) {
+    return $conf;
+  }
+
+  /**
+   * We are within the civicrm module, the drupal root is 2 links
+   * above us, so use that
+   */
+  $currentDir = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  if (file_exists($currentDir . 'settings_location.php')) {
+    include $currentDir . 'settings_location.php';
+  }
+
+  if (defined('CIVICRM_CONFDIR') && !isset($confdir)) {
+    $confdir = CIVICRM_CONFDIR;
+  }
+  else {
+    // make it relative to civicrm.config.php, else php makes it relative
+    // to the script that invokes it
+    $moduleDir  = 'sites' . DIRECTORY_SEPARATOR . 'all' . DIRECTORY_SEPARATOR . 'modules';
+    $contribDir = $moduleDir . DIRECTORY_SEPARATOR . 'contrib';
+    // check for Drupal8
+    if (strpos($currentDir, 'vendor/civicrm/civicrm-core') !== FALSE) {
+      $confdir = $currentDir . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'sites';
     }
+    else {
+      $confdir = $currentDir . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+    }
+  }
 
-    // There is much more complex stuff in d7 - but lets just handle sites/default for now....
-    $candidates[] = "../../sites/default";
-    $candidates[] = "../../../sites/default";
+  if (file_exists($confdir . DIRECTORY_SEPARATOR . 'civicrm.settings.php')) {
+    return $confdir;
+  }
 
-    foreach ($candidates as $candidate) {
-      if (is_dir($candidate)) {
-        return $candidate;
+  if (!file_exists($confdir) && !$skipConfigError) {
+    echo "Could not find valid configuration dir, best guess: $confdir<br/><br/>\n";
+    exit();
+  }
+
+  // Since drupal 7, aliases could be defined in sites/sites.php
+  if (file_exists($confdir . "/sites.php")) {
+    include $confdir . "/sites.php";
+  }
+  else {
+    $sites = array();
+  }
+
+  $phpSelf  = array_key_exists('PHP_SELF', $_SERVER) ? $_SERVER['PHP_SELF'] : '';
+  $httpHost = array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : '';
+
+  $uri = explode('/', $phpSelf);
+  $server = explode('.', implode('.', array_reverse(explode(':', rtrim($httpHost, '.')))));
+  for ($i = count($uri) - 1; $i > 0; $i--) {
+    for ($j = count($server); $j > 0; $j--) {
+      $dir = implode('.', array_slice($server, -$j)) . implode('.', array_slice($uri, 0, $i));
+      if (file_exists("$confdir/$dir/civicrm.settings.php")) {
+        $conf = "$confdir/$dir";
+        return $conf;
+      }
+      // check for alias
+      if (isset($sites[$dir]) && file_exists("$confdir/{$sites[$dir]}/civicrm.settings.php")) {
+        $conf = "$confdir/{$sites[$dir]}";
+        return $conf;
       }
     }
+  }
 
-    throw new Exception(ts('site directory not found'));
+  // Fallback on default locations
+  $candidates[] = "../../sites/default";
+  $candidates[] = "../../../sites/default";
+
+  foreach ($candidates as $candidate) {
+    if (is_dir($candidate)) {
+      return $candidate;
+    }
+  }
+
+  throw new Exception(ts('CiviCRM could not find the Drupal site directory.'));
 }
 
 $settingsFile = civicrm_conf_init() . '/civicrm.settings.php';
 define('CIVICRM_SETTINGS_PATH', $settingsFile);
-$error = @include_once( $settingsFile );
-if ( $error == false ) {
-    echo "Could not load the settings file at: {$settingsFile}\n";
-    exit( );
+$error = @include_once($settingsFile);
+if ($error == FALSE) {
+  echo "Could not load the settings file at: {$settingsFile}\n";
+  exit();
 }


### PR DESCRIPTION
This PR brings back the logic for finding the `civicrm.settings.php`, including support for multi-site (`sites/example.org/civicrm.settings.php`).

I did a bit of cleaning up, but otherwise kept most of the D7 code, while keeping the D8 code that was already there (ex: throwing an exception: I'm not sure if it's a good idea, but I left it as-is).

I tested this on D8 multi-site.

For REST API users, this has a companion PR https://github.com/civicrm/civicrm-core/pull/11958.