### PR TITLE
Allow settings_location.php to be outside civicrm directory (for upgrade reasons)

### DIFF
--- a/civicrm.config.php.drupal
+++ b/civicrm.config.php.drupal
@@ -46,8 +46,25 @@ function civicrm_conf_init() {
    * above us, so use that
    */
   $currentDir = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+
   if (file_exists($currentDir . 'settings_location.php')) {
     include $currentDir . 'settings_location.php';
+  }
+  $potentialDirectories = [
+    $currentDir,
+    $currentDir . '..'  . DIRECTORY_SEPARATOR,
+    $currentDir . '..'  . DIRECTORY_SEPARATOR . '..'  . DIRECTORY_SEPARATOR,
+    $currentDir . '..'  . DIRECTORY_SEPARATOR . '..'  . DIRECTORY_SEPARATOR . '..'  . DIRECTORY_SEPARATOR,
+    $currentDir . '..'  . DIRECTORY_SEPARATOR . '..'  . DIRECTORY_SEPARATOR . '..'  . DIRECTORY_SEPARATOR . '..'  . DIRECTORY_SEPARATOR,
+  ];
+
+  foreach ($potentialDirectories as $potentialDirectory) {
+    // allow for the civicrm_settings_location.php file to be in parent directories
+    // e.g sites where current dir is sites/all/modules/civicrm or sites/all/modules/contrib/civicrm
+    // this means the file with the conf won't be deleted when the tarball is replaced.
+    if (file_exists($potentialDirectory . 'civicrm_settings_location.php')) {
+      include $potentialDirectory . 'civicrm_settings_location.php';
+    }
   }
 
   if (defined('CIVICRM_CONFDIR') && !isset($confdir)) {


### PR DESCRIPTION
We have had a long-standing issue with scripts that bypass our main
route provider needing to find the civicrm.settings.php file, notably
in cases where symlinks or other are present.

I have been looking at whether we could use our route provider for
kcfinder or use an alternative to kcfinder (no obvious candidate
is winning from what I can see).

Using our route provider I have
https://github.com/civicrm/civicrm-core/compare/master...eileenmcnaughton:kcfinder?expand=1#diff-bfe84caf9a6aad542cf0d5177d7105c0R12

However, there are 2 issues I've failed to solve
1) kcfinder adds it's own js scripts with a path relative to
it's own files - see the output in the html file that I included in the
commit.
2) I couldn't seem to get down to just kcfinder output with no drupal
wrapper

Failing to find a reasonably acheivable way to do the above I think
making the use of a file to identify the location of civicrm.settings.php is worth doing.

This patch simply extends the search for location_settings.php
to the folders above the civicrm folder (or a sites folder within them, this being our config)
 - allowing the civicrm_location_settings.php to be in the sites folder
this seems consistent with a drupal approach and means the
recommended CiviCRM practice of deleting the civicrm folder & replacing it does not break
kcfinder.

This is a low-traffic file so any extra file_exists calls seem unimportant.