### PR TITLE
Fix Views custom field handler not displaying select value labels when fields share the same label.

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_custom.inc
+++ b/modules/views/civicrm/civicrm_handler_field_custom.inc
@@ -70,7 +70,7 @@ class civicrm_handler_field_custom extends views_handler_field {
         if (!is_null($value)) {
           // get the field id from the db
           if (!empty($this->definition['title'])) {
-            $customFieldID = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_CustomField', $this->definition['title'], 'id', 'label');
+            $customFieldID = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_CustomField', $this->real_field, 'id', 'column_name');
             return CRM_Core_BAO_CustomField::displayValue($value, $customFieldID);
           }
           // could not get custom id, lets just return what we have


### PR DESCRIPTION
The current handler looks up the CiviCRM custom field ID using the field's
label, which is not intended to be unique. More than one field can exist
across multiple different custom field groups with the same field label. If
that happens, when attempting to pull the list of select field options, the
handler will just use the field with the lowest field ID for all fields that
have the same field label, so the field's value won't get rendered.

This change makes the handler use the field's column_name to look up the
field id, which is unique across all fields in CiviCRM.

To reproduce the bug:
1. Create 2 contact sub-types.
2. Create two custom field groups, one for each of the sub-types created above.
3. For each custom field group, create a custom select field with the same name but different select options.
4. Create one contact for each sub-type and fill in the custom select field created above.
5. Create a new Contact-based View and add the two custom select fields added above and set them to render the label and not the value.
6. Note that one of the fields will display (the one with the lower custom field id), but the other will not. Post-patch, both field values should display.