### PR TITLE
Drupal Views CiviCRM: Allow Participant record to be used from Event.

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -96,6 +96,7 @@ files[] = modules/views/civicrm/civicrm_handler_relationship_phone.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_im.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_website.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_address.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_participant.inc
 
 ; views plugins
 files[] = modules/views/plugins/calendar_plugin_row_civicrm.inc

--- a/modules/views/civicrm/civicrm_handler_relationship_participant.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_participant.inc
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This relationship handler is used when joining the civicrm_relationship table
+ * to the civicrm_contact table. This handler allows us to optionally add conditions
+ * to the join clause based on relationship_type_id and is_active.
+ */
+class civicrm_handler_relationship_participant extends views_handler_relationship {
+  static $participant_types;
+
+  /**
+   * Preload the list of relationship_types and store in the static variable
+   * $relationship_types
+   */
+  public function construct() {
+    parent::construct();
+
+    if (!civicrm_initialize()) {
+      return;
+    }
+    require_once 'CRM/Core/PseudoConstant.php';
+
+    self::$participant_types = CRM_Core_PseudoConstant::participantRoles();
+  }
+
+  /**
+   * Add additional options for relationship_type and relationship_state
+   * to the view. By defining these here, Views will take care of saving the
+   * values submitted from the options form.
+   */
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options['participant_type'] = array('default' => 0);
+    return $options;
+  }
+
+  /**
+   * Add relationship_type drowndown and relationship_state checkbox to
+   * relationship configuration form.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $form['participant_type'] = array(
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#title' => 'Choose a specific Participant type',
+      '#options' => self::$participant_types,
+      '#description' => t('Choose to limit this relationship to one or more specific types of CiviCRM Participant.'),
+      '#default_value' => $this->options['participant_type'],
+    );
+  }
+
+  /**
+   * Modify the default views relationship query to optionally specify
+   * join conditions for relationship_type or is_active (relationship_state).
+   */
+  public function query() {
+    parent::query();
+
+    // Specify the type of relationships to join
+    if (isset($this->options['participant_type']) && $this->options['participant_type']) {
+      $this->query->table_queue[$this->alias]['join']->extra[] = array(
+        'value' => $this->options['participant_type'],
+        'numeric' => TRUE,
+        'field' => 'role_id',
+      );
+    }
+  }
+
+}

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -157,6 +157,18 @@ function _civicrm_core_data(&$data, $enabled) {
     ),
   );
 
+  $data['civicrm_event']['civicrm_participant'] = array(
+    'real field' => 'id',
+    'title' => t('CiviCRM Participant (starting from Event)'),
+    'help' => t('Allows a Participant Contact relationship from an Event'),
+    'relationship' => array(
+      'base' => 'civicrm_participant',
+      'base field' => 'event_id',
+      'handler' => 'civicrm_handler_relationship_participant',
+      'label' => t('CiviCRM Participant (starting from Event)'),
+    ),
+  );
+
   // Drupal ID of the contact (from uf_match.uf_id)
   $data['civicrm_contact']['drupal_id'] = array(
     'real field' => 'id',


### PR DESCRIPTION
Under Drupal Views, there's no relationship that allows a Contact to be connected to an Event by a Participant record.

Outstanding feature: currently using this allows all the default Contact fields, but not custom ones.