### PR TITLE
Update civicrm_rules_event.inc

### DIFF
--- a/modules/civicrm_rules/civicrm_rules_event.inc
+++ b/modules/civicrm_rules/civicrm_rules_event.inc
@@ -47,7 +47,7 @@ function civicrm_rules_get_event() {
     ),
     'contact_edit' =>
     array(
-      'label' => t('Contact has been updated'),
+      'label' => t('Contact has been updated (CiviCRM Event Rule)'),
       'group' => 'CiviCRM Contact',
       'variables' => civicrm_rules_rules_events_variables(t('update contact')),
     ),


### PR DESCRIPTION
There are 3 Rule Events available for CiviCRM Contact: 

* After updating an existing civicrm contact
* CiviCRM Contact has been updated
* Contact has been updated

A little bit hard to find what is the difference. Let us help users by telling that "Contact has been updated" comes from Event.
Perhaps, would be even better to move this one under CiviCRM Events option group.