### PR TITLE
dev/drupal/27 Custom fields with duplicate labels are not displayed correctly in views

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_custom.inc
+++ b/modules/views/civicrm/civicrm_handler_field_custom.inc
@@ -70,7 +70,7 @@ class civicrm_handler_field_custom extends views_handler_field {
         if (!is_null($value)) {
           // get the field id from the db
           if (!empty($this->definition['title'])) {
-            $customFieldID = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_CustomField', $this->definition['title'], 'id', 'label');
+            $customFieldID = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_CustomField', $this->field, 'id', 'column_name');
             return CRM_Core_BAO_CustomField::displayValue($value, $customFieldID);
           }
           // could not get custom id, lets just return what we have


### PR DESCRIPTION
Steps to recreate:

- Create a custom field group associated with organisations, add a field with the label 'Role' (eg: ID 1)
- Create a custom field group associated with individuals, add a field with the label 'Role' (eg: ID 2)
- Create a view which exposes the second 'role' field on a contact record
- The field is always empty

Reason:

- The custom field handler is searching for the field ID based on the label of the field, which is a loose search, it returns the first match, which is ID 1 in the example above.

Remedy:

- Tighten the custom field handler to search for the ID of the field based on the unique column name.