### PR TITLE
Don't render an empty mailto link for empty email addresses

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_email.inc
+++ b/modules/views/civicrm/civicrm_handler_field_email.inc
@@ -57,7 +57,7 @@ class civicrm_handler_field_email extends civicrm_handler_field_location {
   }
 
   public function render($values) {
-    if ($this->options['link_to_user'] == 'mailto') {
+    if ($this->options['link_to_user'] == 'mailto' && !empty($values->{$this->field_alias})) {
       return l($values->{$this->field_alias}, "mailto:" . $values->{$this->field_alias});
     }
     return check_plain($values->{$this->field_alias});


### PR DESCRIPTION
If you add an 'email address' field to a views display, and choose to output it as a mailto link then an empty link is created when the email address is empty; with the link of just 'mailto:'.

This patch makes a change to ensure that an email address is present before outputting a link around it.