### PR TITLE
PHP 7.1 incompatibility error fix for -> Error: Using $this when not in object context in civicrm_form_data()

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -584,10 +584,10 @@ function civicrm_form_data($edit, &$user, $category, $reset, $doNotProcess = FAL
     // do not allow edit for anon users in joomla frontend, CRM-4668, unless u have checksum CRM-5228
     $config = CRM_Core_Config::singleton();
     if ($config->userFrameworkFrontend) {
-      CRM_Contact_BAO_Contact_Permission::validateOnlyChecksum($userID, $this);
+      CRM_Contact_BAO_Contact_Permission::validateOnlyChecksum($userID, $edit);
     }
     else {
-      CRM_Contact_BAO_Contact_Permission::validateChecksumContact($userID, $this);
+      CRM_Contact_BAO_Contact_Permission::validateChecksumContact($userID, $edit);
     }
   }
   $ctype = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $userID, 'contact_type');


### PR DESCRIPTION
I was getting this error when attempting to edit civi profiles exposed to drupal user profiles.

 Error: Using $this when not in object context in civicrm_form_data() (line 590 of sites/all/modules/civicrm/drupal/civicrm.module).

Changing the $this to the available $edit var, which appears to contain the form, seemed to solve the problem.