### PR TITLE
dev/drupal#31 - CiviMember Role sync is no longer syncing Pending mem…

### DIFF
--- a/modules/civicrm_member_roles/civicrm_member_roles.module
+++ b/modules/civicrm_member_roles/civicrm_member_roles.module
@@ -575,7 +575,16 @@ function _civicrm_member_roles_sync($ext_uid = NULL, $cid = NULL, $sync_type = N
         $inactive[] = $value['id'];
       }
       foreach ($memberships['values'] as $key => $membership) {
-        if (in_array($membership['status_id'], $inactive)) {
+        //Do not unset if inactive membership status is chosen as an option for synchronization.
+        $inactiveStatusSync = FALSE;
+        if (!empty($memberroles[$membership['membership_type_id']])) {
+          foreach ($memberroles[$membership['membership_type_id']] as $rolerule) {
+            if (in_array($membership['status_id'], $rolerule['codes']['current'])) {
+              $inactiveStatusSync = TRUE;
+            }
+          }
+        }
+        if (in_array($membership['status_id'], $inactive) && !$inactiveStatusSync) {
           unset($memberships['values'][$key]);
         }
       }


### PR DESCRIPTION
…berships

To reproduce -

- Create a membership role sync rule with  `ADD WHEN STATUS IS` set to `Pending`.
- Create a membership with pending status.
- Login with the contact and check if the role is assigned.

Before changes - Role is not assigned.
After changes - Role is assigned correctly.

Gitlab Issue - https://lab.civicrm.org/dev/drupal/issues/31