### PR TITLE
Bug fix in civicrm.module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-This fork fixes a bug in the civicrm.module file around lines 587-590, regarding the error message `Error: Using $this when not in object context in civicrm_form_data() (line 591 of /path/to/site/sites/all/modules/contrib/civicrm/drupal/civicrm.module).` 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+This fork fixes a bug in the civicrm.module file around lines 587-590, regarding the error message `Error: Using $this when not in object context in civicrm_form_data() (line 591 of /path/to/site/sites/all/modules/contrib/civicrm/drupal/civicrm.module).` 

--- a/civicrm.module
+++ b/civicrm.module
@@ -584,10 +584,10 @@ function civicrm_form_data($edit, &$user, $category, $reset, $doNotProcess = FAL
     // do not allow edit for anon users in joomla frontend, CRM-4668, unless u have checksum CRM-5228
     $config = CRM_Core_Config::singleton();
     if ($config->userFrameworkFrontend) {
-      CRM_Contact_BAO_Contact_Permission::validateOnlyChecksum($userID, $this);
+      CRM_Contact_BAO_Contact_Permission::validateOnlyChecksum($userID, $edit);
     }
     else {
-      CRM_Contact_BAO_Contact_Permission::validateChecksumContact($userID, $this);
+      CRM_Contact_BAO_Contact_Permission::validateChecksumContact($userID, $edit);
     }
   }
   $ctype = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $userID, 'contact_type');


### PR DESCRIPTION
Replaced `$this` with `$edit` in `civicrm_form_data()` when not in object context. 
Ignore the README I made