### PR TITLE
civicrm_handler_field_link_pcp: avoid PHP notice

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_link_pcp.inc
+++ b/modules/views/civicrm/civicrm_handler_field_link_pcp.inc
@@ -107,7 +107,7 @@ class civicrm_handler_field_link_pcp extends views_handler_field {
   }
 
   public function render($values) {
-    return $this->render_link(check_plain($values->{$this->field_alias}), $values);
+    return $this->render_link(NULL, $values);
   }
 
 }


### PR DESCRIPTION
This function generated PHP notices 'Undefined property: stdClass::$unknown',
yet the field_alias is not used anyway in the render_link() function. The change
proposed here is consistent with similar changes elsewhere (ex: 8da894b5).

My view was fairly typical: contact names and page URL (we did rewrite the page URL field so that it links on the page title). Full view: http://paste.debian.net/hidden/5d54a877/