### PR TITLE
dev/core#414: Fixes views group filter

### DIFF
--- a/modules/views/civicrm/civicrm_handler_filter_custom_option.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_custom_option.inc
@@ -85,7 +85,31 @@ class civicrm_handler_filter_custom_option extends views_handler_filter_in_opera
     $op = ($this->operator == 'in' || $this->operator == 'all') ? 'LIKE' : 'NOT LIKE';
     $glue = ($this->operator == 'in') ? 'OR ' : 'AND ';
     foreach ($this->value as $value) {
-      $clauses[] = "$this->table_alias.$this->real_field " . $op . " '%" . $sep . CRM_Core_DAO::escapeString($value) . $sep . "%' ";
+      if (is_array($value)) {
+        // When an exposed group filter is used the $value
+        // is an array. This array looks like:
+        //   'Student' => string 'Student' (length=7)
+        //    'all' => int 0
+        //    'Parent' => int 0
+        //    'Staff' => int 0
+        //    'Volunteer' => int 0
+        //     'Team' => int 0
+        //     'Sponsor' => int 0
+        // As you can see in the above example the value Student is selected.
+        // The value all means any of the values
+        $allValuesSelected = false;
+        if (isset($value['all']) && $value['all']) {
+          $allValuesSelected = true;
+        }
+        unset($value['all']);
+        foreach($value as $subvalue => $isset) {
+          if ($isset || $allValuesSelected) {
+            $clauses[] = "$this->table_alias.$this->real_field " . $op . " '%" . $sep . CRM_Core_DAO::escapeString($subvalue) . $sep . "%' ";
+          }
+        }
+      } else {
+        $clauses[] = "$this->table_alias.$this->real_field " . $op . " '%" . $sep . CRM_Core_DAO::escapeString($value) . $sep . "%' ";
+      }
     }
     $clause = implode($glue, $clauses);
     $this->query->add_where_expression($this->options['group'], $clause);

--- a/modules/views/civicrm/civicrm_handler_filter_custom_option.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_custom_option.inc
@@ -97,17 +97,18 @@ class civicrm_handler_filter_custom_option extends views_handler_filter_in_opera
         //     'Sponsor' => int 0
         // As you can see in the above example the value Student is selected.
         // The value all means any of the values
-        $allValuesSelected = false;
+        $allValuesSelected = FALSE;
         if (isset($value['all']) && $value['all']) {
-          $allValuesSelected = true;
+          $allValuesSelected = TRUE;
         }
         unset($value['all']);
-        foreach($value as $subvalue => $isset) {
+        foreach ($value as $subvalue => $isset) {
           if ($isset || $allValuesSelected) {
             $clauses[] = "$this->table_alias.$this->real_field " . $op . " '%" . $sep . CRM_Core_DAO::escapeString($subvalue) . $sep . "%' ";
           }
         }
-      } else {
+      }
+      else {
         $clauses[] = "$this->table_alias.$this->real_field " . $op . " '%" . $sep . CRM_Core_DAO::escapeString($value) . $sep . "%' ";
       }
     }


### PR DESCRIPTION
# Summary

There was an issue with exposed the contact subtype filter as a grouped filter. The query generated was empty. This PR fixes this.

# Before
 
![before1](https://lab.civicrm.org/dev/core/uploads/2a6a783ba85cf2be4ded2df618e42eec/Group-Filter.JPG)

![before2](https://lab.civicrm.org/dev/core/uploads/36be0b16085264c2069156921e47b0df/Group-Filter-Query.JPG)

# After
![screenshot from 2018-11-08 19-01-31](https://user-images.githubusercontent.com/4126292/48217845-c7168780-e388-11e8-9743-37078789c40c.png)

![screenshot from 2018-11-08 19-02-27](https://user-images.githubusercontent.com/4126292/48217875-df86a200-e388-11e8-969e-66d2dc9b0212.png)

# More information

* issue 414 on GitLab: https://lab.civicrm.org/dev/core/issues/414

