### PR TITLE
CIVICRM-984: Make "Add CiviCRM Tag to Contact" action list tags

### DIFF
--- a/modules/civicrm_rules/civicrm_rules.contact-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.contact-eval.inc
@@ -144,3 +144,24 @@ function civicrm_rules_options_list() {
   $settings['groups'] = _civicrm_get_groups();
   return $settings;
 }
+
+/**
+ * Options list callback for listing of CiviCRM Tags
+ */
+function civicrm_rules_tags_list() {
+  if(!civicrm_initialize()) {
+    return array();
+  }
+  $result = civicrm_api3('tag', 'get', array(
+              'used_for' => 'civicrm_contact',
+              'options'  => array(
+                'limit' => 0,
+                'sort'  => 'name ASC'
+              )
+            ));
+  $values = array();
+  foreach($result['values'] as $tag) {
+    $values[$tag['id']] = $tag['name'];
+  }
+  return $values;
+}

--- a/modules/civicrm_rules/civicrm_rules.contact-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.contact-eval.inc
@@ -156,8 +156,8 @@ function civicrm_rules_tags_list() {
     'used_for' => 'civicrm_contact',
     'options' => array(
       'limit' => 0,
-      'sort' => 'name ASC'
-    )
+      'sort' => 'name ASC',
+    ),
   ));
   $values = array();
   foreach ($result['values'] as $tag) {

--- a/modules/civicrm_rules/civicrm_rules.contact-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.contact-eval.inc
@@ -149,18 +149,18 @@ function civicrm_rules_options_list() {
  * Options list callback for listing of CiviCRM Tags
  */
 function civicrm_rules_tags_list() {
-  if(!civicrm_initialize()) {
+  if (!civicrm_initialize()) {
     return array();
   }
   $result = civicrm_api3('tag', 'get', array(
-              'used_for' => 'civicrm_contact',
-              'options'  => array(
-                'limit' => 0,
-                'sort'  => 'name ASC'
-              )
-            ));
+    'used_for' => 'civicrm_contact',
+    'options' => array(
+      'limit' => 0,
+      'sort' => 'name ASC'
+    )
+  ));
   $values = array();
-  foreach($result['values'] as $tag) {
+  foreach ($result['values'] as $tag) {
     $values[$tag['id']] = $tag['name'];
   }
   return $values;

--- a/modules/civicrm_rules/civicrm_rules_action.inc
+++ b/modules/civicrm_rules/civicrm_rules_action.inc
@@ -96,7 +96,7 @@ The content of the email is:
       'civicrm_tags' => array(
         'type' => 'list<integer>',
         'label' => t('CiviCRM Tags'),
-        'options list' => 'civicrm_rules_options_list',
+        'options list' => 'civicrm_rules_tags_list',
       ),
     ),
     'group' => t('CiviCRM Contact'),


### PR DESCRIPTION
Overview
--------

This corrects the Admin UI of the "Add CiviCRM Tag to Contact" Rules action.

Before
-------

"Add CiviCRM Tag to Contact" lists *Groups* to be added, but operates on Tag ID same as the selected group.

After
-----

"Add CiviCRM Tag to Contact" lists *Tags*.  No change to operation of the action.