### PR TITLE
Add a Views Relationship handler for relating a Contact to their Contributions.

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -89,6 +89,7 @@ files[] = modules/views/civicrm/views_handler_argument_civicrm_year_month.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_relationship.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_contact2users.inc
+files[] = modules/views/civicrm/civicrm_handler_relationship_contacts_contributions.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_memberships_contributions.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_location.inc
 files[] = modules/views/civicrm/civicrm_handler_relationship_mail.inc

--- a/modules/views/civicrm/civicrm_handler_relationship_contacts_contributions.inc
+++ b/modules/views/civicrm/civicrm_handler_relationship_contacts_contributions.inc
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Field handler to provide relationship between contacts and contributions
+ *
+ * @ingroup civicrm_field_handlers
+ */
+class civicrm_handler_relationship_contacts_contributions extends views_handler_relationship {
+
+  /**
+   * Called to implement a relationship in a query.
+   */
+  public function query() {
+    $join_type = empty($this->options['required']) ? 'LEFT' : 'INNER';
+    $this->ensure_my_table();
+    $join = new views_join();
+    $join->definition = array(
+      'table' => 'civicrm_contribution',
+      'field' => 'contact_id',
+      'left_table' => $this->table_alias,
+      'left_field' => 'id',
+      'type' => $join_type,
+    );
+    $join->construct();
+    $join->adjusted = TRUE;
+    $alias = $join->definition['table'] . '_' . $join->definition['left_table'];
+    $this->alias = $this->query->add_relationship($alias, $join, 'civicrm_contribution', $this->relationship);
+  }
+
+}

--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -2454,6 +2454,20 @@ function _civicrm_core_data(&$data, $enabled) {
     ),
   );
 
+  // Link to Contribution table
+  if (isset($enabled['CiviContribute'])) {
+    $data['civicrm_contact']['contribution_id'] = array(
+      'title' => t('Contribution Records'),
+      'help' => 'Contributions records for this Contact',
+      'relationship' => array(
+        'base' => 'civicrm_contribution',
+        'base field' => 'id',
+        'handler' => 'civicrm_handler_relationship_contacts_contributions',
+        'label' => t('Contact -> Contribution'),
+      ),
+    );
+  }
+
   //----------------------------------------------------------------
   // CIVICRM Relationships are here with all the connections, base tabling it up.
   //----------------------------------------------------------------


### PR DESCRIPTION
The existing Views integration allows for pulling in Contributions related to
a Contact via indirect methods, like from a related Participant or Membership
record. Doing so does not allow Contribution Custom Fields to be used in the
View, though. This change adds an explicit Relationship between Contacts and
Contribution which, when added to a View, allows for pulling in Custom Field
data for Contributions.