### PR TITLE
Fix path for civicrm.settings.php when installed in profiles/

### DIFF
--- a/civicrm.config.php.drupal
+++ b/civicrm.config.php.drupal
@@ -58,6 +58,7 @@ function civicrm_conf_init() {
     // to the script that invokes it
     $moduleDir  = 'sites' . DIRECTORY_SEPARATOR . 'all' . DIRECTORY_SEPARATOR . 'modules';
     $contribDir = $moduleDir . DIRECTORY_SEPARATOR . 'contrib';
+    $profileDir = DIRECTORY_SEPARATOR . 'profiles' . DIRECTORY_SEPARATOR;
     // check to see if this is under sites/all/modules/contrib or subdir civicrm-core
     if (strpos($currentDir, $contribDir) !== FALSE || strpos($currentDir, 'civicrm-core') !== FALSE) {
       $confdir = $currentDir . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..';
@@ -65,6 +66,17 @@ function civicrm_conf_init() {
     // check to see if this is under sites/all/modules
     elseif (strpos($currentDir, $moduleDir) !== FALSE) {
       $confdir = $currentDir . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..';
+    }
+    // check to see if this is under profiles/[PROFILE]/modules
+    elseif (strpos($currentDir, $profileDir) !== FALSE) {
+      // check to see if this is under profiles/[PROFILE]/modules/contrib
+      if (strpos($currentDir, "contrib") !== FALSE) {
+        $sublevels = 5;
+      }
+      else {
+        $sublevels = 4;
+      }
+      $confdir = $currentDir . str_repeat('..' . DIRECTORY_SEPARATOR, $sublevels) . 'sites';
     }
     else {
       $confdir = $currentDir . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;


### PR DESCRIPTION
When CiviCRM is installed in a Drupal's distribution profile, under **profiles/<profile_name>/modules/[contrib]**, the funciton `civicrm_conf_init()` doesn't return the proper path for file **civicrm.settings.php**.

In most of cases CiviCRM works fine without this patch, but it fails i.e. when calling an API using REST, returns this error:
```
Could not load the settings file at: /var/www/drupal/profiles/myCustomProfile/modules/contrib/civicrm/../..//default/civicrm.settings.php
```