### PR TITLE
Bump php version to match core requirements

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -4,7 +4,7 @@ version = 7.x-4.7
 package = CiviCRM
 core = 7.x
 project = civicrm
-php = 5.3
+php = 5.6
 
 files[] = civicrm.module
 files[] = civicrm.install


### PR DESCRIPTION
We no longer support php < 5.6.