### PR TITLE
Enable contribution views to filter on empty Receipt and Thank You dates

### DIFF
--- a/modules/views/components/civicrm.contribute.inc
+++ b/modules/views/components/civicrm.contribute.inc
@@ -404,6 +404,7 @@ function _civicrm_contribute_data(&$data, $enabled) {
     'filter' => array(
       'handler' => 'civicrm_handler_filter_datetime',
       'is date' => TRUE,
+      'allow empty' => TRUE,
     ),
     'sort' => array(
       'handler' => 'civicrm_handler_sort_date',
@@ -425,6 +426,7 @@ function _civicrm_contribute_data(&$data, $enabled) {
     'filter' => array(
       'handler' => 'civicrm_handler_filter_datetime',
       'is date' => TRUE,
+      'allow empty' => TRUE,
     ),
     'sort' => array(
       'handler' => 'civicrm_handler_sort_date',


### PR DESCRIPTION
Adding `'allow empty' => TRUE` to filter definitions for dates enables the `is empty` / `is not empty` filter options.

Useful if you want a view showing contributions that have/have not been thanked.

Before: A view filter on Thank You date or Receipt Date does not offer empty/not empty

After: A view filter on Thank You date or Receipt Date does offer empty/not empty