### PR TITLE
dev/drupal#58 - Add Contact ID operator to the contact reference filt…

### DIFF
--- a/modules/views/civicrm/civicrm_handler_filter_contact_ref.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_contact_ref.inc
@@ -44,12 +44,35 @@ class civicrm_handler_filter_contact_ref extends views_handler_filter_string {
   }
 
   /**
-   * Adds where clause to the view query to filter
-   * by contact sort_name instead of id.
-   *
    * @param string $field
    */
-  public function filterContactRef($field) {
+  public function op_contact_id($field) {
+    $this->operator = '=';
+    $this->filterContactRef($field, 'id');
+  }
+
+  /**
+   * Add Contact ID to the list of operators.
+   */
+  public function operators() {
+    $op = parent::operators();
+    $op['contact_id'] = [
+      'title' => t('Contact ID'),
+      'short' => t('contact_id'),
+      'method' => 'op_contact_id',
+      'values' => 1,
+    ];
+    return $op;
+  }
+
+  /**
+   * Adds where clause to the view query to filter
+   * by contact sort_name OR id based on operator selected.
+   *
+   * @param string $field
+   * @param string $fieldName
+   */
+  public function filterContactRef($field, $fieldName = 'sort_name') {
     if (!empty($this->value)) {
       $op = $this->operator;
       if ($this->operator != '=' && $this->operator != '!=') {
@@ -58,7 +81,7 @@ class civicrm_handler_filter_contact_ref extends views_handler_filter_string {
       }
       $contacts = db_select('civicrm_contact', 'cc')
         ->fields('cc', array('id'))
-        ->condition('cc.sort_name', $this->value, $op);
+        ->condition("cc.{$fieldName}", $this->value, $op);
 
       $this->query->add_where($this->options['group'], $field, $contacts, 'IN');
     }


### PR DESCRIPTION
…er added in drupal view

Contact Reference filter in a Drupal view only lets user to filter on sort_name. This field can have duplicate values on multiple contact records. It might be helpful if we could filter the results based on contact id.

Use-case

- Add a contact ref custom field on a custom set extending individual. Eg `Alternate Contact Person`
- Add value to this field eg "Ashlie Adams".
- Suppose the db have more than one contact having the same sort name. eg id 203 and 206
- I need to create a Drupal view filtering values which have `Alternate Contact Person` set to contact id 203.
- The current set of filters will list all contacts for 203 and 206.
- This ticket is to address that limitation, i.e, adds contact id to the list of operators -

![image](https://user-images.githubusercontent.com/5929648/56488680-bdc74480-64fc-11e9-8f8c-4fbdecb87ce2.png)

Gitlab - https://lab.civicrm.org/dev/drupal/issues/58