### PR TITLE
(dev/drupal#79) Fail more gracefully when upgrading on PHP 5.x

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -4,7 +4,7 @@ version = 7.x-4.7
 package = CiviCRM
 core = 7.x
 project = civicrm
-php = 5.6
+php = 7.0
 
 files[] = civicrm.module
 files[] = civicrm.install

--- a/civicrm.module
+++ b/civicrm.module
@@ -33,6 +33,19 @@ require_once 'civicrm_user.inc';
 define('CIVICRM_UF_HEAD', TRUE);
 
 /**
+ * Minimum required PHP
+ *
+ * Note: This duplicates CRM_Upgrade_Form::MINIMUM_PHP_VERSION. The
+ * duplication helps avoid a dependency-loop. (Reading `Form::MINIMUM_PHP_VERSION`
+ * requires loading `civicrm.settings.php`, but that triggers a parse-error
+ * on PHP 5.x.)
+ *
+ * @see CRM_Upgrade_Form::MINIMUM_PHP_VERSION
+ * @see CiviDrupal\PhpVersionTest::testConstantMatch()
+ */
+define('CIVICRM_DRUPAL_PHP_MINIMUM', '7.0.0');
+
+/**
  * Adds CiviCRM CSS and JS resources into the header.
  */
 function civicrm_html_head() {
@@ -149,9 +162,8 @@ function civicrm_page_build($page) {
  */
 function civicrm_initialize() {
   // Check for php version and ensure its greater than minPhpVersion
-  $minPhpVersion = '5.3.4';
-  if (version_compare(PHP_VERSION, $minPhpVersion) < 0) {
-    echo "CiviCRM requires PHP Version $minPhpVersion or greater. You are running PHP Version " . PHP_VERSION . "<p>";
+  if (version_compare(PHP_VERSION, CIVICRM_DRUPAL_PHP_MINIMUM) < 0) {
+    echo "CiviCRM requires PHP " . CIVICRM_DRUPAL_PHP_MINIMUM . "+. The web server is running PHP " . PHP_VERSION . ".<p>";
     exit();
   }
   _civicrm_registerClassLoader();

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -1456,6 +1456,13 @@ function _civicrm_init($fail = TRUE, $load_config = TRUE) {
     return $init;
   }
 
+  if (!version_compare(phpversion(), CIVICRM_DRUPAL_PHP_MINIMUM, '>=')) {
+    return drush_set_error('CIVICRM_PHP_MINIMUM', dt('CiviCRM requires PHP @required+. Drush is running PHP @current.', [
+      '@current' => phpversion(),
+      '@required' => CIVICRM_DRUPAL_PHP_MINIMUM,
+    ]));
+  }
+
   global $cmsPath;
   $cmsPath = $drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT');
   $site_root = drush_get_context('DRUSH_DRUPAL_SITE_ROOT', FALSE);

--- a/tests/phpunit/CiviDrupal/PhpVersionTest.php
+++ b/tests/phpunit/CiviDrupal/PhpVersionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace CiviDrupal;
+
+use Civi\Test\EndToEndInterface;
+
+class PhpVersionTest extends \PHPUnit_Framework_TestCase implements EndToEndInterface {
+
+  /**
+   * CIVICRM_DRUPAL_PHP_MINIMUM (civicrm.module) should match MINIMUM_PHP_VERSION (CRM/Upgrade/Form.php).
+   */
+  public function testConstantMatch() {
+    $constantFile = $this->getDrupalModulePath() . '/civicrm.module';
+    $this->assertFileExists($constantFile);
+    $content = file_get_contents($constantFile);
+    if (preg_match(";define\\('CIVICRM_DRUPAL_PHP_MINIMUM', '(.*)'\\);", $content, $m)) {
+      $this->assertEquals(\CRM_Upgrade_Form::MINIMUM_PHP_VERSION, $m[1]);
+    }
+    else {
+      $this->fail('Failed to find CIVICRM_DRUPAL_PHP_MINIMUM in ' . $constantFile);
+    }
+  }
+
+  /**
+   * "php" requirement (civicrm.info) should match MINIMUM_PHP_VERSION (CRM/Upgrade/Form.php).
+   */
+  public function testInfoMatch() {
+    $infoFile = $this->getDrupalModulePath() . '/civicrm.info';
+    $this->assertFileExists($infoFile);
+    $info = drupal_parse_info_file($infoFile);
+    $expectMajorMinor = preg_replace(';^(\d+\.\d+)\..*$;', '\1', \CRM_Upgrade_Form::MINIMUM_PHP_VERSION);
+    $this->assertEquals($expectMajorMinor, $info['php']);
+  }
+
+  /**
+   * @return string
+   *   Ex: '/var/www/sites/all/modules/civicrm/drupal'
+   */
+  protected function getDrupalModulePath() {
+    return dirname(dirname(dirname(__DIR__)));
+  }
+
+}


### PR DESCRIPTION
This version requirement officially went up to PHP 7.0 circa Civi 5.14. However, at that time, the upgrade metadata was kept at PHP 5.6 to allow somewhat softer landing for stragglers.  That's no longer possible in Civi 5.16+,

This just gives a clearer error when someone tries to upgrade with PHP 5.x.

Depends: https://github.com/civicrm/civicrm-core/pull/15082

Before
------

When upgrading via drush or Drupal web UI on PHP 5.6, the Civi class-loader fails to initialize.

```
Parse error: syntax error, unexpected ':', expecting '{' 
in /Users/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/vendor/league/csv/src/functions.php on line 33
```

(Approximate call-path: `civicrm.drush.inc | civicrm.module` =>
`civicrm.settings.php` => `CRM_Core_ClassLoader` => `vendor/autoload.php` =>
`vendor/league/csv/src/functions.php`)

After
-----

When upgrading via drush on PHP 5.6, the error points to the actual problem.

```
[bknix-old:~/bknix/build/dmaster/web/sites/all/modules/civicrm] drush civicrm-upgrade-db
CiviCRM requires PHP 7.0.0+. Drush is running PHP 5.6.38.                                                                                                                [error]
```

When upgrading via web UI on PHP 5.6, the error message is similar:

```
CiviCRM requires PHP 7.0.0+. The web server is running PHP 5.6.38.
```

(Note: I tweaked the text to emphasize that the PHP version is determined by the "drush" or "web server" environment - in some systems, these are different environments with different PHP versions.  A phrase like "your version" can be confusing/misleading in those cases.)

Comments
--------

The canonical representation of the minimum PHP version is in `$civicrm_root/CRM/Upgrade/Form.php`.  However, correctly reading that metadata requires loading `civicrm.settings.php`, which triggers the crash.

To work around this, we reproduce the constant and use a unit-test to ensure its continued accuracy.

Also, it seems useful to put the same metadata in `civicrm.info`.  I'm not sure if D7 uses this in a meaningful way, but it's good to be accurate.