### PR TITLE
Bump minimum PHP version to be 7.1 (Do not merge until 5.24 RC is cut)

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -4,7 +4,7 @@ version = 7.x-4.7
 package = CiviCRM
 core = 7.x
 project = civicrm
-php = 7.0
+php = 7.1
 
 files[] = civicrm.module
 files[] = civicrm.install

--- a/civicrm.module
+++ b/civicrm.module
@@ -43,7 +43,7 @@ define('CIVICRM_UF_HEAD', TRUE);
  * @see CRM_Upgrade_Form::MINIMUM_PHP_VERSION
  * @see CiviDrupal\PhpVersionTest::testConstantMatch()
  */
-define('CIVICRM_DRUPAL_PHP_MINIMUM', '7.0.0');
+define('CIVICRM_DRUPAL_PHP_MINIMUM', '7.1.0');
 
 /**
  * Adds CiviCRM CSS and JS resources into the header.


### PR DESCRIPTION
This should be merged at the same time as https://github.com/civicrm/civicrm-core/pull/16678