### PR TITLE
Fix Views relationship to addresses

### DIFF
--- a/modules/views/civicrm.views.inc
+++ b/modules/views/civicrm.views.inc
@@ -201,7 +201,8 @@ function civicrm_views_url($path, $query, $absolute = FALSE) {
  *   (optional) Array of fields not to add form the $fields table
  */
 function civicrm_views_add_fields(&$fields, &$data, $tableName, &$skipFields = NULL) {
-  foreach ($fields as $name => $value) {
+  foreach ($fields as $value) {
+    $name = $value['name'];
     // Only add fields not in $data or $skipFields and has a ['title']
     if (isset($value['custom_field_id']) ||
       CRM_Utils_Array::value($name, $skipFields) ||


### PR DESCRIPTION
This fixes https://lab.civicrm.org/dev/drupal/issues/110.

**Note**: Screenshots, extended explanation, and a review by @herbdool are all on lab.c.o.

In Civi 5.23 (core#1512), we [changed the XML definition](https://github.com/civicrm/civicrm-core/commit/7e18723f949bccca27529042b656ff4db4b88741#diff-df534ce59221c12505f93f67ccd9dac5) of `civicrm_address.id` to give it a `uniqueName` of `address_id`.  However, Views integration has a function `civicrm_views_add_fields` that is unaware of the concept of `uniqueName`, so it treats the results of `$fields = CRM_Core_DAO_Address::fields();` as if the array keys and the `name` property are interchangeable.  E.g. it assumes `$field['randomfield']['name'] == 'randomfield'`.  However, with unique names, in this case ` `$field['id']['name] == 'address_id'`.

In `civicrm_views_add_fields`, those two values are used interchangeably.  This fix ensures we are consistently using the correct value.
