### PR TITLE
provide Calendar module with end_date when duration is provided

### DIFF
--- a/modules/views/plugins/calendar_plugin_row_civicrm.inc
+++ b/modules/views/plugins/calendar_plugin_row_civicrm.inc
@@ -190,8 +190,19 @@ class calendar_plugin_row_civicrm extends calendar_plugin_row {
       }
       elseif (!$is_field && !empty($item)) {
         $item_start_date = new dateObject($item, $db_tz);
-        $item_end_date   = $item_start_date;
-        $node->date_id   = array('calendar.' . $node->id . '.' . $field_name . '.0');
+        $node->date_id = array('calendar.' . $node->id . '.' . $field_name . '.0');
+        // If we have a civicrm_activity_duration let's use it!
+        // Calculate the end_date so that the calendar item can have the correct height in the week and day displays.
+        // NOTE: imported views can have a bug that causes $view->style_options['groupby_times'] not to be set.
+        // Solution (for each display/page): go into the View -> Calendar -> Settings: Time Grouping -> save;
+        if (isset($row->civicrm_activity_duration)) {
+          $duration = $row->civicrm_activity_duration;
+          $item_value2 = date("Y-m-d H:i:s", strtotime($item . '+' . $duration . 'minutes'));
+          $item_end_date = new dateObject($item_value2, $db_tz);
+        }
+        else {
+          $item_end_date = $item_start_date;
+        }
       }
 
       // If we don't have date value, go no further.


### PR DESCRIPTION
Sharing this enhancement. It provides a very important enhancement for scheduling activities. 

**Before:** a CiviCRM calendar item only has a start_date so Drupal Calendar module only renders enough yellow block to ensure the text is encapsulated.

![image](https://user-images.githubusercontent.com/5340555/77854171-db3d6d80-71a5-11ea-9a82-29f8e5cddb54.png)

**After:** now constructing an end_date based on activity_duration -> if it exists in the View (regardless of whether it's displayed or not) use it. We now have a properly sized yellow block. The activity_duration in this example is 120 min and that is properly visualized:

![image](https://user-images.githubusercontent.com/5340555/77854778-826fd400-71a9-11ea-9949-678886b46be8.png)

