### PR TITLE
Installation - Support "activate first" w/setup UI

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -36,6 +36,11 @@ function civicrm_enable() {
   menu_link_save($options);
 
   if (!civicrm_initialize()) {
+    $installLink = url('civicrm/setup');
+    $message = t('<p class="error"><strong>CiviCRM is almost ready.</strong> You must <a href="@url">configure CiviCRM</a> for it to work.</p>', [
+      '@url' => $installLink,
+    ]);
+    drupal_set_message($message);
     return;
   }
 
@@ -63,6 +68,27 @@ function civicrm_uninstall() {
 
   require_once 'CRM/Core/DAO.php';
   CRM_Core_DAO::dropAllTables();
+}
+
+function civicrm_requirements($phase) {
+  $requirements = array();
+  $t = get_t();
+  switch ($phase) {
+    case 'runtime':
+      if (!civicrm_initialize()) {
+        $installLink = url('civicrm/setup');
+        $requirements['civicrm'] = array(
+          'title' => $t("CiviCRM"),
+          'severity' => REQUIREMENT_ERROR,
+          'value' => $t('<p class="error"><strong>CiviCRM is almost ready.</strong> You must <a href="@url">configure CiviCRM</a> for it to work.</p>', [
+            '@url' => $installLink,
+          ]),
+        );
+        return $requirements;
+      }
+      break;
+  }
+  return $requirements;
 }
 
 /**

--- a/civicrm.install
+++ b/civicrm.install
@@ -65,35 +65,6 @@ function civicrm_uninstall() {
   CRM_Core_DAO::dropAllTables();
 }
 
-function civicrm_requirements($phase) {
-  global $base_url;
-  $civicrm_path = drupal_get_path('module', 'civicrm');
-
-  //remove the last occurrence of 'drupal' from path
-  $pos = strrpos($civicrm_path, 'drupal');
-
-  if ($pos !== FALSE) {
-    $civicrm_path = substr_replace($civicrm_path, '', $pos, strlen($civicrm_path));
-  }
-
-  $url = $base_url . '/' . $civicrm_path . 'install/index.php';
-
-  $settings = glob('sites/*/civicrm.settings.php');
-  $problems = array();
-  $t = get_t();
-  if (empty($settings) && $phase == 'install') {
-    $problems[] = array(
-      'title' => $t('CiviCRM settings does not exist'),
-      'value' =>
-      $t('CiviCRM settings file does not exist. It should be created by CiviCRM <a href="!link">install</a>',
-        array('!link' => $url)),
-      'severity' => REQUIREMENT_ERROR,
-    );
-  }
-
-  return $problems;
-}
-
 /**
  * Update CiviCRM module weight
  */

--- a/civicrm.module
+++ b/civicrm.module
@@ -487,6 +487,10 @@ function _civicrm_categories_access($profile_id) {
  * Translating profile menu title dynamicaly to overide caching
  */
 function civicrm_menu_alter(&$items) {
+  if (!civicrm_initialize()) {
+    return;
+  }
+
   $categories = civicrm_user_categories();
   foreach ($categories as $cat) {
     $path = 'user/%user_category/edit/' . $cat['name'];

--- a/civicrm.module
+++ b/civicrm.module
@@ -119,6 +119,14 @@ function civicrm_menu() {
       'type' => 4,
       'weight' => 0,
     ),
+    'civicrm/setup' => array(
+      'title' => 'CiviCRM Setup',
+      'access callback' => TRUE,
+      'page callback' => 'civicrm_setup_page',
+      'file' => 'civicrm.setup.inc',
+      'type' => 4,
+      'weight' => 0,
+    ),
     // administration section for civicrm integration modules.
     'admin/config/civicrm' => array(
       'title' => 'CiviCRM',
@@ -197,11 +205,7 @@ function civicrm_initialize() {
     if (!$loadedSettings) {
       $failure = TRUE;
       if (user_access('administer modules')) {
-        $installLink = url('civicrm');
-        $message = t('<p class="error"><strong>CiviCRM is almost ready.</strong> You must <a href="@url">configure CiviCRM</a> for it to work.</p>', [
-          '@url' => $installLink,
-        ]);
-        drupal_set_message($message);
+
       }
       return FALSE;
     }

--- a/civicrm.module
+++ b/civicrm.module
@@ -111,10 +111,6 @@ function civicrm_block_view($delta = '0') {
  * Implements hook_menu().
  */
 function civicrm_menu() {
-  if (!civicrm_initialize()) {
-    return;
-  }
-
   return array(
     'civicrm' => array(
       'title' => 'CiviCRM',
@@ -197,13 +193,16 @@ function civicrm_initialize() {
       )
     );
 
-    if (!include_once $settingsFile) {
+    $loadedSettings = (bool) @include_once $settingsFile;
+    if (!$loadedSettings) {
       $failure = TRUE;
-      $message = t("<strong><p class='error'> Oops! - The CiviCRM settings file (civicrm.settings.php) was not found in the expected location (!1) </p><p class='error'> !2 </p></strong>", array(
-        '!1' => $settingsFile,
-        '!2' => $errorMsgAdd,
-      ));
-      drupal_set_message($message);
+      if (user_access('administer modules')) {
+        $installLink = url('civicrm');
+        $message = t('<p class="error"><strong>CiviCRM is almost ready.</strong> You must <a href="@url">configure CiviCRM</a> for it to work.</p>', [
+          '@url' => $installLink,
+        ]);
+        drupal_set_message($message);
+      }
       return FALSE;
     }
 
@@ -386,7 +385,9 @@ function civicrm_invoke() {
 
   // make sure the system is initialized
   if (!civicrm_initialize()) {
-    return drupal_not_found();
+    require_once __DIR__ . '/civicrm.setup.inc';
+    // NOTE: The setup page has a built-in authorization check.
+    return civicrm_setup_page();
   }
 
   civicrm_cache_disable();

--- a/civicrm.module
+++ b/civicrm.module
@@ -90,7 +90,7 @@ function civicrm_permission() {
  */
 function civicrm_block_info() {
   if (!civicrm_initialize()) {
-    return;
+    return [];
   }
   $block = CRM_Core_Block::getInfo();
   return $block;
@@ -887,7 +887,9 @@ function civicrm_user_admin_permissions_submit($form, &$form_state) {
   if ($rid === FALSE) {
     return;
   }
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   $roles = user_roles();
   $permissions = array_filter($form_state['values'][$rid]);
   $warning_permissions = CRM_Core_Permission::validateForPermissionWarnings($permissions);
@@ -1025,7 +1027,10 @@ function _civicrm_filter_tips($filter, $format, $long = FALSE) {
  * @return bool|mixed|string
  */
 function _civicrm_filter_process($text, $filter, $format, $langcode, $cache, $cache_id) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return t('(Content unavailable. CiviCRM is not installed.)');
+  }
+
   $config = CRM_Core_Config::singleton();
   $smarty = CRM_Core_Smarty::singleton();
   // as this file is not a class (not sure why) we need the require once
@@ -1218,7 +1223,9 @@ function civicrm_reviews() {
  * Implements hook_modules_installed().
  */
 function civicrm_modules_installed($modules) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 }
 
@@ -1226,7 +1233,9 @@ function civicrm_modules_installed($modules) {
  * Implements hook_modules_enabled().
  */
 function civicrm_modules_enabled($modules) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 }
 
@@ -1234,7 +1243,9 @@ function civicrm_modules_enabled($modules) {
  * Implements hook_modules_disabled().
  */
 function civicrm_modules_disabled($modules) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 }
 
@@ -1242,7 +1253,9 @@ function civicrm_modules_disabled($modules) {
  * Implements hook_modules_uninstalled().
  */
 function civicrm_modules_uninstalled($modules) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 }
 

--- a/civicrm.setup.inc
+++ b/civicrm.setup.inc
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * (Page callback)
+ *
+ * @return string
+ */
+function civicrm_setup_page() {
+  $coreUrl = dirname(file_create_url(drupal_get_path('module', 'civicrm')));
+  $corePath = dirname(__DIR__);
+  $classLoader = implode(DIRECTORY_SEPARATOR, [$corePath, 'CRM', 'Core', 'ClassLoader.php']);
+
+  if (file_exists($classLoader)) {
+    require_once $classLoader;
+    CRM_Core_ClassLoader::singleton()->register();
+    \Civi\Setup::assertProtocolCompatibility(1.0);
+    \Civi\Setup::init([
+      // This is just enough information to get going. Drupal.civi-setup.php does more scanning.
+      'cms' => 'Drupal',
+      'srcPath' => $corePath,
+    ]);
+    $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
+    $ctrl->setUrls(array(
+      'ctrl' => url('civicrm'),
+      'res' => $coreUrl . '/setup/res/',
+      'jquery.js' => $coreUrl . '/bower_components/jquery/dist/jquery.min.js',
+      'font-awesome.css' => $coreUrl . '/bower_components/font-awesome/css/font-awesome.min.css',
+      // Not used? 'finished' => url('civicrm/dashboard', ['query' => ['reset' => 1],]),
+    ));
+    \Civi\Setup\BasicRunner::run($ctrl);
+    exit();
+  }
+  else {
+    drupal_set_message(t('Cannot perform setup for CiviCRM. The file "@file" is missing.', [
+      '@file' => $classLoader,
+    ]), 'error');
+    return '';
+  }
+}
+
+///**
+// * This is a draft alternative to BasicRunner. It would theoretically enable
+// * Drupal's chrome. However, the styling is a little wonky, and you wind up
+// * with two <HTML>s. Maybe worth fixing someday - but not now.
+// *
+// * @param \Civi\Setup\UI\SetupControllerInterface $ctrl
+// * @return mixed
+// */
+//function _civicrm_setup_runCtrl($ctrl) {
+//  $method = $_SERVER['REQUEST_METHOD'];
+//  list ($headers, $body) = $ctrl->run($method, ($method === 'GET' ? $_GET : $_POST));
+//  foreach ($headers as $k => $v) {
+//    drupal_add_http_header($k, $v, TRUE);
+//  }
+//  return $body;
+//}

--- a/civicrm_user.inc
+++ b/civicrm_user.inc
@@ -123,7 +123,7 @@ function civicrm_user_delete($account) {
  */
 function civicrm_user_categories() {
   if (!civicrm_initialize()) {
-    return;
+    return [];
   }
   $urlParts = explode('/', CRM_Utils_Array::value('q', $_GET, array()));
 

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -540,7 +540,10 @@ function civicrm_drush_help($section) {
  * Implementation of command 'civicrm-ext-list'
  */
 function drush_civicrm_ext_list() {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    drush_print(dt("CiviCRM is not setup."));
+    return;
+  }
   try {
     $result = civicrm_api3('extension', 'get', array(
       'options' => array(
@@ -570,7 +573,10 @@ function drush_civicrm_ext_list() {
  * Implementation of command 'civicrm-ext-install'
  */
 function drush_civicrm_ext_install($extension_name) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    drush_print(dt("CiviCRM is not setup."));
+    return;
+  }
   try {
     $result = civicrm_api('extension', 'install', array('key' => $extension_name, 'version' => 3));
     if ($result['values'] && $result['values'] == 1) {
@@ -593,7 +599,10 @@ function drush_civicrm_ext_install($extension_name) {
  * Implementation of command 'civicrm-ext-disable'
  */
 function drush_civicrm_ext_disable($extension_name) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    drush_print(dt("CiviCRM is not setup."));
+    return;
+  }
   try {
     $result = civicrm_api('extension', 'disable', array('key' => $extension_name, 'version' => 3));
     if ($result['values'] && $result['values'] == 1) {
@@ -616,7 +625,10 @@ function drush_civicrm_ext_disable($extension_name) {
  * Implementation of command 'civicrm-ext-uninstall'
  */
 function drush_civicrm_ext_uninstall($extension_name) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    drush_print(dt("CiviCRM is not setup."));
+    return;
+  }
   try {
     $result = civicrm_api('extension', 'uninstall', array('key' => $extension_name, 'version' => 3));
     if ($result['values'] && $result['values'] == 1) {
@@ -1538,7 +1550,10 @@ function drush_civicrm_api() {
       break;
   }
 
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    drush_print(dt("CiviCRM is not setup."));
+    return;
+  }
 
   global $user;
   CRM_Core_BAO_UFMatch::synchronize($user, FALSE, 'Drupal',
@@ -1569,7 +1584,10 @@ function drush_civicrm_api() {
  * Implementation of command 'civicrm-sync-users-contacts'
  */
 function drush_civicrm_sync_users_contacts() {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    drush_print(dt("CiviCRM is not setup."));
+    return;
+  }
   $result = CRM_Utils_System::synchronizeUsers();
   $status = ts('Checked one user record.',
     array(
@@ -1598,7 +1616,10 @@ function drush_civicrm_sync_users_contacts() {
 
 function drush_civicrm_sql_rebuild_triggers() {
   $table = drush_get_option('table', NULL);
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    drush_print(dt("CiviCRM is not setup."));
+    return;
+  }
   $triggerService = Civi::service('sql_triggers');
   $triggerService->rebuild($table, TRUE);
   if (\Civi::settings()->get('logging_no_trigger_permission')) {


### PR DESCRIPTION
Overview
----------

This adds support for installing CiviCRM-Drupal through the [Setup API](https://docs.civicrm.org/dev/en/latest/framework/setup/new-installer/). Most notable changes:

* Better layout and more useful options on the installation screen
* Extensible installation logic - under the hood, this installer can initialize settings, toggle extensions, etc.
* Reusable installation logic - can run the same installation code for CLI and web UI
* No need to bypass regular module activation or bypass router (no need for `install/index.php` entry-point)

Note: This is a port of https://github.com/civicrm/civicrm-backdrop/pull/121 to D7.

Before
------

The sysadmin downloads the CiviCRM module - but they must *not* install it. Instead, navigate to this path:

```
http://example.org/modules/civicrm/install/index.php
```

This is a special, standalone entry-point.

After
-----

After downloading the CiviCRM module, you simply enable it like any module. Then use any link to open a CiviCRM page (e.g. there are links in the post-install status-message and in the main menu). The page will display the setup screen.

For a sense of how it looks, here's a screenshot+mp4 from the Backdrop variant:

![Screen Shot 2020-07-03 at 11 17 37 PM](https://user-images.githubusercontent.com/1336047/86506346-72a4f480-bd83-11ea-88c8-3c986e4a7ba6.png)

http://think.hm/tmp/Backdrop-Civicrm-Setup.mp4

Technical Details
-----------------

1. The old install screen is still available as a fallback (in case there's some edge-case that got missed).
2. The basic gist of this change is:
    * Ensure that all CiviCRM-Drupal hooks fail gracefully (in the absence of `civicrm.settings.php`). Many already do - there were just a couple oddballs.
    * Update the handling of `civicrm/*` URLs. If CiviCRM cannot initialize, then show the [civicrm-setup web installer](https://docs.civicrm.org/dev/en/latest/framework/setup/new-installer/#web-installer-api).
3. This is the same API used in [the newer Civi-WP installer](https://github.com/civicrm/civicrm-wordpress/blob/5.28/civicrm.php#L1189-L1207). (*Note: For historical reasons, the Civi-WP has a few extra contingencies that aren't needed here.*)
4. When testing/`r-run`ning, here are some of things that I tried:
    * Enable the module and try to view it as regular/non-admin user. Regular users cannot perform installation.
    * Install via web UI 
    * Install via CLI (`cv core:install -vv --cms-base-url=http://dmaster.bknix:8001`), with the `civicrm.module` enabled or disabled
    * Install in US English or French.
4. During development, my workflow went a bit like this:
    1. Create D7 site with CiviCRM codebase -- but without installing. (*I specifically used a modified `civibuild` with the `drupal-demo` type - ie hack `app/config/demo-demo/install.sh` to skip most of the install logic. Then run `civibuild create dmaster` or `civibuild reinstall dmaster`*)
    2. Login.
    3. Make a new DB snapshot (eg `civibuild snapshot dmaster`). (This way my login-session is part of the snapshot.)
    4. Repeatedly do the following:
        * Edit code
        * Use the installer - and see how it goes.
        * Cleanup: `./bin/cv.phar core:uninstall -f ; civibuild restore dmaster ; rm -rf ~/bknix/build/dmaster/web/files/civicrm/`
5. This depends on another PR for civicrm-core: https://github.com/civicrm/civicrm-core/pull/17749