### PR TITLE
dev/core#1929 Fix filter handler for custom field

### DIFF
--- a/modules/views/civicrm/civicrm_handler_filter_custom_option.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_custom_option.inc
@@ -31,15 +31,10 @@ class civicrm_handler_filter_custom_option extends views_handler_filter_in_opera
         $this->value_options = CRM_Contact_BAO_ContactType::subTypePairs();
       }
       else {
-        // extract the field id from the name
-        if (preg_match('/_(\d+)$/', $this->real_field, $match)) {
-          require_once 'CRM/Core/BAO/CustomOption.php';
-          $options = CRM_Core_BAO_CustomOption::getCustomOption($match[1]);
-        }
-        if (is_array($options)) {
-          foreach ($options as $id => $opt) {
-            $this->value_options[$opt['value']] = strip_tags($opt['label']);
-          }
+        $customFieldID = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_CustomField', $this->real_field, 'id', 'column_name');
+        $options = (array) CRM_Core_BAO_CustomOption::getCustomOption($customFieldID);
+        foreach ($options as $id => $opt) {
+          $this->value_options[$opt['value']] = strip_tags($opt['label']);
         }
       }
     }

--- a/modules/views/civicrm/civicrm_handler_filter_custom_single_option.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_custom_single_option.inc
@@ -25,15 +25,11 @@ class civicrm_handler_filter_custom_single_option extends views_handler_filter_i
 
   public function get_value_options() {
     if (!isset($this->value_options)) {
-      // extract the field id from the name
-      if (preg_match('/_(\d+)$/', $this->real_field, $match)) {
-        require_once 'CRM/Core/BAO/CustomOption.php';
-        $options = CRM_Core_BAO_CustomOption::getCustomOption($match[1]);
-      }
-      if (is_array($options)) {
-        foreach ($options as $id => $opt) {
-          $this->value_options[$opt['value']] = strip_tags($opt['label']);
-        }
+      $customFieldID = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_CustomField', $this->real_field, 'id', 'column_name');
+      $options = (array) CRM_Core_BAO_CustomOption::getCustomOption($customFieldID);
+
+      foreach ($options as $id => $opt) {
+        $this->value_options[$opt['value']] = strip_tags($opt['label']);
       }
     }
   }


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/-/issues/1929

If the column_name is specified when the custom field is created, it does not contain the field id, but the handler currently assumes it does.

Change how the field id is determined and use the method currently in civicrm_handler_field_custom.inc