### PR TITLE
Allow for the setting of an additional constant CIVICRM_DRUSH_DSN

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -1362,8 +1362,8 @@ function drush_civicrm_post_civicrm_sqlcli() {
  * Creates a db_url based on CIVICRM_DSN or cli_db_url setting
  */
 function civicrm_db_array() {
-  if (defined('CIVICRM_DRUSH_DSN')) {
-    $url = CIVICRM_DRUSH_DSN;
+  if (defined('CIVICRM_CLI_DSN')) {
+    $url = CIVICRM_CLI_DSN;
   }
   else {
     $url = CIVICRM_DSN;

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -1371,7 +1371,6 @@ function civicrm_db_array() {
   return drush_convert_db_from_db_url($url);
 }
 
-
 function _civicrm_dsn_init($reset = FALSE) {
   static $globalDbUrl = NULL;
 

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -1358,6 +1358,20 @@ function drush_civicrm_post_civicrm_sqlcli() {
   _civicrm_dsn_close();
 }
 
+/**
+ * Creates a db_url based on CIVICRM_DSN or cli_db_url setting
+ */
+function civicrm_db_array() {
+  if (defined('CIVICRM_DRUSH_DSN')) {
+    $url = CIVICRM_DRUSH_DSN;
+  }
+  else {
+    $url = CIVICRM_DSN;
+  }
+  return drush_convert_db_from_db_url($url);
+}
+
+
 function _civicrm_dsn_init($reset = FALSE) {
   static $globalDbUrl = NULL;
 
@@ -1376,7 +1390,7 @@ function _civicrm_dsn_init($reset = FALSE) {
         $globalDbUrl = $GLOBALS['databases'][$database][$target];
       }
       // now modify $GLOBALS so that drush works on CIVICRM_DSN instead of drupal's
-      $GLOBALS['databases'][$database][$target] = drush_convert_db_from_db_url(CIVICRM_DSN);
+      $GLOBALS['databases'][$database][$target] = civicrm_db_array();
     }
   }
   else {


### PR DESCRIPTION
In the rpow civicrm extension that allows users to have separate read and write databases, the CIVICRM_DSN string is non-conventional "civirpow://" drush_convert_db_from_db_url cannot convert to an array. This allows for another constant CIVICRM_DRUSH_DSN so that drush can use a friendlier string to set up the database connection.

In conjunction with https://github.com/totten/rpow/pull/7
