### PR TITLE
Advice in failure message is out of date

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -212,8 +212,9 @@ function civicrm_initialize() {
 
     // this does pretty much all of the civicrm initialization
     if (!include_once 'CRM/Core/Config.php') {
+      // Note the failure variable is tied by reference to a static.
       $failure = TRUE;
-      drupal_set_message(t("<strong><p class='error'>Oops! - The path for including CiviCRM code files is not set properly. Most likely there is an error in the <em>civicrm_root</em> setting in your CiviCRM settings file (!1). </p><p class='error'> &raquo; civicrm_root is currently set to: <em>!2</em></p><p class='error'>!3</p></strong>", array(
+      drupal_set_message(t("<strong><p class='error'>Oops! - Unable to load CRM/Core/Config.php. Most likely the file is missing or there is an error in your CiviCRM settings file (!1). </p><p class='error'> &raquo; civicrm_root is currently set to: <em>!2</em></p><p class='error'>!3</p></strong>", array(
         '!1' => $settingsFile,
         '!2' => $civicrm_root,
         '!3' => $errorMsgAdd,


### PR DESCRIPTION
Follow on to https://github.com/civicrm/civicrm-drupal/pull/624

If you try to r-run to see the message that was updated in that PR, you can't do it by having an incorrect civicrm_root as the message suggests. Probably that was true at one time but now if civicrm_root is wrong it doesn't even get this far to see the message, so the advice should be more on point about what failed.

I considered removing the entire reference to civicrm_root since it might lead them astray, but at least the main reason is stated now.

Drupal 8 has the same problem - see https://github.com/civicrm/civicrm-drupal-8/pull/48

FYI @MikeyMJCO 