### PR TITLE
allow filtering by empty event end, registration start, registration …

### DIFF
--- a/modules/views/components/civicrm.event.inc
+++ b/modules/views/components/civicrm.event.inc
@@ -241,6 +241,7 @@ function _civicrm_event_data(&$data, $enabled) {
     'filter' => array(
       'handler' => 'civicrm_handler_filter_datetime',
       'is date' => TRUE,
+      'allow empty' => TRUE,
     ),
     'sort' => array(
       'handler' => 'civicrm_handler_sort_date',
@@ -278,6 +279,7 @@ function _civicrm_event_data(&$data, $enabled) {
     'filter' => array(
       'handler' => 'civicrm_handler_filter_datetime',
       'is date' => TRUE,
+      'allow empty' => TRUE,
     ),
     'sort' => array(
       'handler' => 'civicrm_handler_sort_date',
@@ -299,6 +301,7 @@ function _civicrm_event_data(&$data, $enabled) {
     'filter' => array(
       'handler' => 'civicrm_handler_filter_datetime',
       'is date' => TRUE,
+      'allow empty' => TRUE,
     ),
     'sort' => array(
       'handler' => 'civicrm_handler_sort_date',


### PR DESCRIPTION
…end dates

Of the date fields on `civicrm_event` - start date, end date, registration start date, registration end date - only "start date" is required.  However, Views can't search for empty dates without explicitly specifying a date can be empty.  This adds that specification to the three event dates that aren't required.