### PR TITLE
dev/core#2258 - Define CIVICRM_CRED_KEYS during drush installation

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -487,7 +487,8 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     'CMSdbPass' => $db_spec['password'],
     'CMSdbHost' => $db_spec['host'],
     'CMSdbName' => $db_spec['database'],
-    'siteKey' => md5(uniqid('', TRUE) . $baseUrl),
+    'siteKey' => preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(32))),
+    'credKeys' => 'aes-cbc:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(32))),
   ];
   $str = file_get_contents($settingsTplFile);
   foreach ($params as $key => $value) {


### PR DESCRIPTION
When using `drush civicrm-install`, the `civicrm.settings.php` should provide a credential-key.

See also: https://github.com/civicrm/civicrm-core/pull/19349 and https://lab.civicrm.org/dev/core/-/issues/2258

Here's an example usage:

```
## Remove old installation
[bknix-min:~/bknix/build/dmaster/web/sites/all/modules/civicrm/drupal] cv core:uninstall --db='mysql://dmasterciv_f6xwh:********@127.0.0.1:3307/dmastercivi_ssc8b?ne
w_link=true'
Found code for civicrm-core in /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm
Found code for civicrm-setup in /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/setup
Found civicrm_* database tables in dmastercivi_ssc8b
Found civicrm.settings.php in /home/totten/bknix/build/dmaster/web/sites/default

Are you sure want to purge the CiviCRM database and data files? Data may be permanently destroyed. (y/N) y
Removing civicrm_* database tables in dmastercivi_ssc8b
Removing civicrm.settings.php from /home/totten/bknix/build/dmaster/web/sites/default

## Install Civi
[bknix-min:~/bknix/build/dmaster/web/sites/all/modules/civicrm/drupal] drush civicrm-install --site_url='dmaster.bknix:8001' --dbhost=127.0.0.01:3307 --dbname=dmastercivi_ssc8b --dbuser=dmasterciv_f6xwh --dbpass=********  --destination=sites/all/modules
CiviCRM database loaded successfully.                                                                                                                            [ok]
Settings file generated: /home/totten/bknix/build/dmaster/web/sites/default/civicrm.settings.php                                                                 [ok]
CiviCRM installed.                                                                                                                                               [ok]

## Work around quirk of drush installer
[bknix-min:~/bknix/build/dmaster/web/sites/all/modules/civicrm/drupal] drush ev 'civicrm_initialize();'

## Inspect the generated settings
[bknix-min:~/bknix/build/dmaster/web/sites/all/modules/civicrm/drupal] cv ev 'print_r(Civi::service("crypto.registry")->getKeys()); print_r([CIVICRM_CRED_KEYS]);'
Array
(
    [plain] => Array
        (
            [key] => 
            [suite] => plain
            [tags] => Array
                (
                )

            [id] => plain
            [weight] => 32768
        )

    [plain0] => Array
        (
            [suite] => plain
            [weight] => 32768
            [tags] => Array
                (
                    [0] => CRED
                )

            [id] => plain0
        )

    [********] => Array
        (
            [suite] => aes-cbc
            [weight] => 0
            [key] => ********
            [tags] => Array
                (
                    [0] => CRED
                )

            [id] => ********
        )

)
Array
(
    [0] => aes-cbc:hkdf-sha256:********
)

```