### PR TITLE
dev/core#2204 Update minimum php install to be 7.2

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -4,7 +4,7 @@ version = 7.x-4.7
 package = CiviCRM
 core = 7.x
 project = civicrm
-php = 7.1
+php = 7.2
 
 files[] = civicrm.module
 files[] = civicrm.install

--- a/civicrm.module
+++ b/civicrm.module
@@ -41,7 +41,7 @@ define('CIVICRM_UF_HEAD', TRUE);
  * @see CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER
  * @see CiviDrupal\PhpVersionTest::testConstantMatch()
  */
-define('CIVICRM_DRUPAL_PHP_MINIMUM', '7.1.0');
+define('CIVICRM_DRUPAL_PHP_MINIMUM', '7.2.0');
 
 /**
  * Adds CiviCRM CSS and JS resources into the header.


### PR DESCRIPTION
as per https://github.com/civicrm/civicrm-core/pull/19390 this updates the minimum install php version to be 7.2