### PR TITLE
civicrm_handler_filter_pseudo_constant - Guard against old or inactive pseudoconstants

### DIFF
--- a/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
@@ -40,8 +40,15 @@ class civicrm_handler_filter_pseudo_constant extends views_handler_filter_in_ope
       $pseudo_args = array();
     }
 
-    // Include and call the Pseudo Class method
-    $this->_pseudo_constant = call_user_func_array($this->definition['pseudo class'] . "::" . $this->definition['pseudo method'], $pseudo_args);
+    $callback = $this->definition['pseudo class'] . "::" . $this->definition['pseudo method'];
+    if (is_callable($callback)) {
+      $this->_pseudo_constant = call_user_func_array($callback, $pseudo_args);
+      // Do we really need to resolve this during `construct()`ion? There's on-demand caching in `get_value_options()`.
+    }
+    else {
+      vpr('civicrm_handler_filter_pseudo_constant - handler @callback is unavailable ', ['@callback' => $callback]);
+      $this->_pseudo_constant = [];
+    }
   }
 
   public function get_value_options() {

--- a/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
@@ -40,7 +40,6 @@ class civicrm_handler_filter_pseudo_constant extends views_handler_filter_in_ope
       $pseudo_args = array();
     }
 
-    require_once str_replace('_', DIRECTORY_SEPARATOR, $this->definition['pseudo class']) . '.php';
     // Include and call the Pseudo Class method
     $this->_pseudo_constant = call_user_func_array($this->definition['pseudo class'] . "::" . $this->definition['pseudo method'], $pseudo_args);
   }


### PR DESCRIPTION
Example 1: You install an extension which defines some data (pseudo-constant).  A view depends on that data.  You remove the extension.  It shouldn't crash.

Example 2: Upgrading to 5.47.x with CiviGrant installed.  You have some views that rely on CiviGrant.  During upgrade/migration, it momentarily disables CiviGrant (component) -- and then later re-enables CiviGrant (extension).  If there's a system-flush during the interim, the CiviGrant data isn't available yet. Don't crash.

Note: I haven't tested this patch. It's a draft based on reading error-report/backtrace.