### PR TITLE
Fix Undefined variable: custom_link in civicrm_handler_field_link_con…

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_link_contact.inc
+++ b/modules/views/civicrm/civicrm_handler_field_link_contact.inc
@@ -94,6 +94,7 @@ class civicrm_handler_field_link_contact extends views_handler_field {
             "reset=1&cid={$values->id}"
           );
         }
+      break;
 
         // LINKING TO CONTACT EDIT PAGE
       case 'edit':
@@ -103,6 +104,7 @@ class civicrm_handler_field_link_contact extends views_handler_field {
             "reset=1&action=update&cid={$values->id}"
           );
         }
+      break;
 
         // LINKING TO CONTACT DELETE PAGE
       case 'delete':
@@ -112,16 +114,17 @@ class civicrm_handler_field_link_contact extends views_handler_field {
             "reset=1&delete=1&cid={$values->id}"
           );
         }
+      break;
 
         // CUSTOM NODE LINKAGE, GOOD FOR LINKING TO OTHER VIEWS WITH AN ARGUMENT
       case 'custom':
         if ($custom_link !== NULL && $custom_link !== '' && $link_text !== NULL && $link_text !== '') {
           return l($link_text, $custom_link . "{$values->id}");
         }
-        // IF THE OTHER CASES AREN'T IN PLAY, THEN JUST PRINT THE TEXT
-      default:
-        return $link_text;
+      break;
+
     }
+    return $link_text;
   }
 
   public function query() {

--- a/modules/views/civicrm/civicrm_handler_field_link_contact.inc
+++ b/modules/views/civicrm/civicrm_handler_field_link_contact.inc
@@ -94,9 +94,9 @@ class civicrm_handler_field_link_contact extends views_handler_field {
             "reset=1&cid={$values->id}"
           );
         }
-      break;
+        break;
 
-        // LINKING TO CONTACT EDIT PAGE
+      // LINKING TO CONTACT EDIT PAGE
       case 'edit':
         if (user_access('edit all contacts') && $link_text !== NULL && $link_text !== '') {
           return civicrm_views_href($link_text,
@@ -104,9 +104,9 @@ class civicrm_handler_field_link_contact extends views_handler_field {
             "reset=1&action=update&cid={$values->id}"
           );
         }
-      break;
+        break;
 
-        // LINKING TO CONTACT DELETE PAGE
+      // LINKING TO CONTACT DELETE PAGE
       case 'delete':
         if (user_access('edit all contacts') && $link_text !== NULL && $link_text !== '') {
           return civicrm_views_href($link_text,
@@ -114,14 +114,14 @@ class civicrm_handler_field_link_contact extends views_handler_field {
             "reset=1&delete=1&cid={$values->id}"
           );
         }
-      break;
+        break;
 
-        // CUSTOM NODE LINKAGE, GOOD FOR LINKING TO OTHER VIEWS WITH AN ARGUMENT
+      // CUSTOM NODE LINKAGE, GOOD FOR LINKING TO OTHER VIEWS WITH AN ARGUMENT
       case 'custom':
         if ($custom_link !== NULL && $custom_link !== '' && $link_text !== NULL && $link_text !== '') {
           return l($link_text, $custom_link . "{$values->id}");
         }
-      break;
+        break;
 
     }
     return $link_text;


### PR DESCRIPTION
This is a PR to fix the PHP Notice: Undefined variable: custom_link in civicrm_handler_field_link_contact->render_link() (line 118 of civicrm/drupal/modules/views/civicrm/civicrm_handler_field_link_contact.inc). 

Was discussed in the following issue: https://lab.civicrm.org/dev/drupal/-/issues/168#note_85146