### PR TITLE
Fix PHP Notice: Undefined offset in _civicrm_member_roles_sync()

### DIFF
--- a/modules/civicrm_member_roles/civicrm_member_roles.module
+++ b/modules/civicrm_member_roles/civicrm_member_roles.module
@@ -604,7 +604,7 @@ function _civicrm_member_roles_sync($ext_uid = NULL, $cid = NULL, $sync_type = N
         if (!empty($rid)) {
           db_delete('users_roles')->condition('uid', $uid)->condition('rid', $rid, $roleCondition)->execute();
         }
-        if (is_array($memberroles[$membership['membership_type_id']])) {
+        if (isset($memberroles[$membership['membership_type_id']]) && is_array($memberroles[$membership['membership_type_id']])) {
           foreach ($memberroles[$membership['membership_type_id']] as $rolerule) {
             if (in_array($membership['status_id'], $rolerule['codes']['current'])) {
               $addRoles[] = $rolerule['rid'];


### PR DESCRIPTION
This is a fix for Notice: Undefined offset: x in \_civicrm_member_roles_sync() (line 607 of /civicrm/drupal/modules/civicrm_member_roles/civicrm_member_roles.module).

Details can be found in the issue queue here: https://lab.civicrm.org/dev/core/-/issues/3935

PS: I'm working off a branch of my Fork of civicrm-drupal so hopefully this time I've got all my duck in a row.