### PR TITLE
Use the backend theme when upgrading

### DIFF
--- a/modules/civicrmtheme/civicrmtheme.module
+++ b/modules/civicrmtheme/civicrmtheme.module
@@ -88,9 +88,6 @@ function civicrmtheme_custom_theme() {
   if (arg(0) != 'civicrm') {
     return;
   }
-  if (arg(1) == 'upgrade') {
-    return;
-  }
 
   $admin_theme = variable_get('civicrmtheme_theme_admin', 0);
   $public_theme = variable_get('civicrmtheme_theme_public', 0);


### PR DESCRIPTION
Related core PR:
https://github.com/civicrm/civicrm-core/pull/25961

This change was initially introduced in CiviCRM 4.2 to avoid issues when upgrading, but we could not find any reason to keep it that way today. Using the backend theme will make it easier to provide consistent theming accross CMS-es and also usually avoids some frontend CMS features to kick-in, such as Views.