### PR TITLE
Use full setting path rather than relative

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -179,9 +179,10 @@ function civicrm_initialize() {
 
   if (!$initialized) {
     if (function_exists('conf_path')) {
-      $settingsFile = conf_path() . '/civicrm.settings.php';
+      $settingsFile = DRUPAL_ROOT . '/' . conf_path() . '/civicrm.settings.php';
     }
     else {
+      // @todo - ensure this is not providing a relative path
       $settingsFile = conf_init() . '/civicrm.settings.php';
     }
     if (!defined('CIVICRM_SETTINGS_PATH')) {


### PR DESCRIPTION
This makes the setting of CIVICRM_SETTINGS_PATH consistent with other places and addresses a build bug