### PR TITLE
Views notice fix. Remove duplicate call to constructor.

### DIFF
--- a/modules/views/civicrm/civicrm_handler_field_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_field_pseudo_constant.inc
@@ -21,7 +21,6 @@ class civicrm_handler_field_pseudo_constant extends views_handler_field {
 
   public function construct() {
     parent::construct();
-    parent::construct();
     if (!civicrm_initialize() ||
       !isset($this->definition['pseudo class']) ||
       !isset($this->definition['pseudo method'])

--- a/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
+++ b/modules/views/civicrm/civicrm_handler_filter_pseudo_constant.inc
@@ -43,6 +43,9 @@ class civicrm_handler_filter_pseudo_constant extends views_handler_filter_in_ope
     $callback = $this->definition['pseudo class'] . "::" . $this->definition['pseudo method'];
     if (is_callable($callback)) {
       $this->_pseudo_constant = call_user_func_array($callback, $pseudo_args);
+      if ($this->_pseudo_constant === FALSE) {
+        $this->_pseudo_constant = [];
+      }
       // Do we really need to resolve this during `construct()`ion? There's on-demand caching in `get_value_options()`.
     }
     else {


### PR DESCRIPTION
Minor followup to https://github.com/civicrm/civicrm-core/pull/27358

Look down a few lines where it defaults to array, and then down a few more lines where it's expecting an array to loop over.