### PR TITLE
phpunit.xml.dist - Fix compatibility with phpunit9

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,10 +15,4 @@
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./CiviDrupal</directory>
-    </whitelist>
-  </filter>
 </phpunit>


### PR DESCRIPTION
For 5.65+, Civi was generally generally switched from `phpunit8` to `phpunit9`. There were some anomalies/delays in running the `CiviDrupal` suite on phpunit9. This fixes compatibility with phpunit9, so we should get more consistent test-results.