### PR TITLE
Fix Deprecated  string interpolation issue in civicrm.module (line 10…

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -1055,7 +1055,7 @@ function _civicrm_filter_process($text, $filter, $format, $langcode, $cache, $ca
 
   $was_secure       = $smarty->security;
   $smarty->security = TRUE;
-  $text             = $smarty->fetch("string:${text}");
+  $text             = $smarty->fetch("string:{$text}");
   $smarty->security = $was_secure;
 
   // In the use-case of embedding Smarty codes inside a Drupal page, one is likely


### PR DESCRIPTION
Resolves [#4694](https://lab.civicrm.org/dev/core/-/issues/4694)

Fixes Deprecated ${} string interpolation issue in civicrm.module (line 1058 of /civicrm/drupal/civicrm.module).

In PHP 8.2 ${} string interpolation has been deprecated:
https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation

> echo "Hello ${name}"; // Deprecated
> echo "Hello {$name}"; // Supported
