### PR TITLE
dev/core#4695 Fix Deprecated function: Optional parameter declared before required

### DIFF
--- a/modules/civicrm_rules/civicrm_rules.contact-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.contact-eval.inc
@@ -24,7 +24,7 @@
  */
 require_once 'civicrm_rules_utils.inc';
 
-function civicrm_rules_rules_action_contact_send_email($to, $subject, $message, $from = NULL, $settings, RulesState $state, RulesPlugin $element) {
+function civicrm_rules_rules_action_contact_send_email($to, $subject, $message, string $from = NULL, $settings, RulesState $state, RulesPlugin $element) {
 
   $to = str_replace(array("\r", "\n"), ',', $to);
   $toEmails = explode(',', $to);

--- a/modules/civicrm_rules/civicrm_rules.contact-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.contact-eval.inc
@@ -24,7 +24,7 @@
  */
 require_once 'civicrm_rules_utils.inc';
 
-function civicrm_rules_rules_action_contact_send_email($to, $subject, $message, string $from = NULL, $settings, RulesState $state, RulesPlugin $element) {
+function civicrm_rules_rules_action_contact_send_email($to, $subject, $message, $from, $settings, RulesState $state, RulesPlugin $element) {
 
   $to = str_replace(array("\r", "\n"), ',', $to);
   $toEmails = explode(',', $to);

--- a/modules/civicrm_rules/civicrm_rules.mailing-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.mailing-eval.inc
@@ -20,7 +20,7 @@ require_once 'civicrm_rules_utils.inc';
 function civicrm_rules_rules_action_mailing_send_email($to,
   $subject,
   $message,
-  $from = NULL,
+  string $from = NULL,
   $settings,
   RulesState $state,
   RulesPlugin $element

--- a/modules/civicrm_rules/civicrm_rules.mailing-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.mailing-eval.inc
@@ -20,7 +20,7 @@ require_once 'civicrm_rules_utils.inc';
 function civicrm_rules_rules_action_mailing_send_email($to,
   $subject,
   $message,
-  string $from = NULL,
+  $from,
   $settings,
   RulesState $state,
   RulesPlugin $element


### PR DESCRIPTION
Resolves [#4695](https://lab.civicrm.org/dev/core/-/issues/4695)

In PHP 8.2 declaring an optional parameter before a required parameter has been deprecated.
https://php.watch/versions/8.0/deprecate-required-param-after-optional  

The sites that this issue impacts use the Drupal Rules module in their workflow so this may be an issue that is only specific to sites that use Drupal Rules. I don't know if that is the case for certain. 