### PR TITLE
Replace db_delete with user_save for consistency in process

### DIFF
--- a/modules/civicrm_member_roles/civicrm_member_roles.module
+++ b/modules/civicrm_member_roles/civicrm_member_roles.module
@@ -597,7 +597,12 @@ function _civicrm_member_roles_sync($ext_uid = NULL, $cid = NULL, $sync_type = N
     $roleCondition = is_array($rid) ? 'IN' : '=';
 
     if (empty($contactMemberships) && !empty($rid)) {
-      db_delete('users_roles')->condition('uid', $uid)->condition('rid', $rid, $roleCondition)->execute();
+      $account = user_load($uid, TRUE);
+      if ($account !== FALSE) {
+        $rolesRetain = array_diff_key($account->roles, array_flip($rid));
+        // Remove the user roles set by membership.
+        user_save($account, array('roles' => $rolesRetain));
+      }
     }
     else {
       foreach ($contactMemberships as $membership) {


### PR DESCRIPTION
Replace db_delete with user_save for consistency in process

- When membership status gets updated in civicrm, civicrm_member_roles module update user with role change using user_save() function.
- Same process not followed for membership status gets deleted.
- We use db_delete() function to delete user role from that specific user.
- We face this issue when we are syncing user status with cognito & found out that in this case no user hooks gets executed like hook_user_update() or hook_user_presave().
- For consistency we need to utilise same user_save() function so functionalities dependent on this will keep intact.