### PR TITLE
Setup UI - Restore icons (FontAwesome 6 support)

### DIFF
--- a/civicrm.setup.inc
+++ b/civicrm.setup.inc
@@ -24,7 +24,7 @@ function civicrm_setup_page() {
       'ctrl' => url('civicrm'),
       'res' => $coreUrl . '/setup/res/',
       'jquery.js' => $coreUrl . '/bower_components/jquery/dist/jquery.min.js',
-      'font-awesome.css' => $coreUrl . '/bower_components/font-awesome/css/font-awesome.min.css',
+      'font-awesome.css' => $coreUrl . '/bower_components/font-awesome/css/all.min.css',
       // Not used? 'finished' => url('civicrm/dashboard', ['query' => ['reset' => 1],]),
     ));
     \Civi\Setup\BasicRunner::run($ctrl);


### PR DESCRIPTION
Follow-up to 5.77.alpha's https://github.com/civicrm/civicrm-core/pull/30779 

Problem+fix are identical to https://github.com/civicrm/civicrm-backdrop/pull/183

(EDIT) This was already applied on `7.x-master` (#683) but also needed for 5.77.