### PR TITLE
Switch to less-deprecated buildOptions function

### DIFF
--- a/modules/civicrm_engage/Engage/Report/Form/CallList.php
+++ b/modules/civicrm_engage/Engage/Report/Form/CallList.php
@@ -259,7 +259,7 @@ class Engage_Report_Form_CallList extends Engage_Report_Form_List {
 
   public function alterDisplay(&$rows) {
     // custom code to alter rows
-    $genderList = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
+    $genderList = CRM_Contact_DAO_Contact::buildOptions('gender_id');
     $entryFound = FALSE;
     foreach ($rows as $rowNum => $row) {
       // handle state province

--- a/modules/civicrm_engage/Engage/Report/Form/WalkList.php
+++ b/modules/civicrm_engage/Engage/Report/Form/WalkList.php
@@ -100,7 +100,7 @@ class Engage_Report_Form_WalkList extends Engage_Report_Form_List {
             'title' => ts('Sex'),
             'operatorType' => CRM_Report_Form::OP_SELECT,
             'type' => CRM_Report_Form::OP_STRING,
-            'options' => array('' => '') + CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id'),
+            'options' => array('' => '') + CRM_Contact_DAO_Contact::buildOptions('gender_id'),
           ),
           'sort_name' => array(
             'title' => ts('Contact Name'),
@@ -302,7 +302,7 @@ class Engage_Report_Form_WalkList extends Engage_Report_Form_List {
     }
     // custom code to alter rows
     //var_dump($rows);
-    $genderList = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
+    $genderList = CRM_Contact_DAO_Contact::buildOptions('gender_id');
     $entryFound = FALSE;
     foreach ($rows as $rowNum => $row) {
       // handle state province
@@ -412,7 +412,7 @@ class Engage_Report_Form_WalkList extends Engage_Report_Form_List {
                  DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci";
     CRM_Core_DAO::executeQuery($sql);
 
-    $gender = CRM_Core_PseudoConstant::get('CRM_Contact_DAO_Contact', 'gender_id');
+    $gender = CRM_Contact_DAO_Contact::buildOptions('gender_id');
 
     foreach ($rows as $key => $value) {
 


### PR DESCRIPTION
This updates some very old code in the `civiengage` module.

Followup question: why do we still ship the `civiengage` module in our core package?