### PR TITLE
dev/core#5951 Fetch contact_id if not present

### DIFF
--- a/modules/civicrm_member_roles/civicrm_member_roles.module
+++ b/modules/civicrm_member_roles/civicrm_member_roles.module
@@ -688,6 +688,9 @@ function _civicrm_member_roles_get_data($type) {
 function civicrm_member_roles_civicrm_post($op, $objname, $objid, &$objref) {
   if ($objname == "Membership") {
     if (in_array('update', variable_get('civicrm_member_roles_sync_method', array('login')), TRUE)) {
+      if (!$objref->contact_id) {
+        $objref->find(TRUE);
+      }
       _civicrm_member_roles_sync(NULL, $objref->contact_id);
     }
   }


### PR DESCRIPTION
Addresses the possibility that contact_id may not be passed to hook