### PR TITLE
Remove Unnecessary Loading Of Themes For Mailing Urls

### DIFF
--- a/modules/civicrmtheme/civicrmtheme.module
+++ b/modules/civicrmtheme/civicrmtheme.module
@@ -85,7 +85,7 @@ function civicrmtheme_system_themes_admin_form_submit($form, &$form_state) {
  * Implements hook_custom_theme().
  */
 function civicrmtheme_custom_theme() {
-  if (arg(0) != 'civicrm') {
+  if (arg(0) != 'civicrm' || (arg(1) === 'mailing' && in_array(arg(2), ['open', 'url']))) {
     return;
   }
 


### PR DESCRIPTION
## Overview
This PR restricts the loading of civicrm themes for mailing open and mailing url tracking events as these does not require the theme loading and unnecessarily increases the server load which can bring entire site down if the mailing list is big.