### PR TITLE
Remove fallback call to conf_init from drupal 6

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -174,13 +174,7 @@ function civicrm_initialize() {
   }
 
   if (!$initialized) {
-    if (function_exists('conf_path')) {
-      $settingsFile = DRUPAL_ROOT . '/' . conf_path() . '/civicrm.settings.php';
-    }
-    else {
-      // @todo - ensure this is not providing a relative path
-      $settingsFile = conf_init() . '/civicrm.settings.php';
-    }
+    $settingsFile = DRUPAL_ROOT . '/' . conf_path() . '/civicrm.settings.php';
     if (!defined('CIVICRM_SETTINGS_PATH')) {
       define('CIVICRM_SETTINGS_PATH', $settingsFile);
     }


### PR DESCRIPTION
conf_path was added sometime in drupal 6, and then conf_init was removed (renamed) in drupal 7 alpha1: https://git.drupalcode.org/project/drupal/-/commit/ef09cf93e5ac3b0a3783170c6f29fdc4f9df6224

There is no conf_init in drupal 7.